### PR TITLE
Standalone development build support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ Builds/VisualStudio2010/Signalizer.sln.ide/
 Source/backup/
 Builds/VisualStudio2010/.vs/
 Make/__pycache__/
+Make/Logs/
 Builds/Release/
 Builds/x64/
 Releases/

--- a/Builds/LinuxMakefile/Makefile
+++ b/Builds/LinuxMakefile/Makefile
@@ -39,7 +39,7 @@ ifeq ($(CONFIG),Debug)
     TARGET_ARCH := 
   endif
 
-  JUCE_CPPFLAGS := $(DEPFLAGS) "-DLINUX=1" "-DDEBUG=1" "-D_DEBUG=1" "-DCPL_TRACEGUARD_ENTRYPOINTS" "-DJUCER_LINUX_MAKE_6D53C8B4=1" "-DJUCE_APP_VERSION=0.5.0" "-DJUCE_APP_VERSION_HEX=0x500" $(shell $(PKG_CONFIG) --cflags freetype2 fontconfig gl) -pthread -I../../External/juce/modules/juce_audio_processors_headless/format_types/VST3_SDK -I../../../SDKs/vstsdk2.4 -I../../JuceLibraryCode -I../../External/juce/modules -I../../External -I../../Source -I../../Source/Config $(CPPFLAGS)
+  JUCE_CPPFLAGS := $(DEPFLAGS) "-DLINUX=1" "-DDEBUG=1" "-D_DEBUG=1" "-DCPL_TRACEGUARD_ENTRYPOINTS" "-DJUCER_LINUX_MAKE_6D53C8B4=1" "-DJUCE_APP_VERSION=0.5.0" "-DJUCE_APP_VERSION_HEX=0x500" $(shell $(PKG_CONFIG) --cflags alsa freetype2 fontconfig gl) -pthread -I../../External/juce/modules/juce_audio_processors_headless/format_types/VST3_SDK -I../../../SDKs/vstsdk2.4 -I../../JuceLibraryCode -I../../External/juce/modules -I../../External -I../../Source -I../../Source/Config $(CPPFLAGS)
 
   JUCE_CPPFLAGS_VST :=  "-DJucePlugin_Build_VST=1" "-DJucePlugin_Build_VST3=0" "-DJucePlugin_Build_AU=0" "-DJucePlugin_Build_AUv3=0" "-DJucePlugin_Build_AAX=0" "-DJucePlugin_Build_Standalone=0" "-DJucePlugin_Build_Unity=0" "-DJucePlugin_Build_LV2=0"
   JUCE_CFLAGS_VST := -fPIC -fvisibility=hidden
@@ -58,7 +58,10 @@ ifeq ($(CONFIG),Debug)
   JUCE_VST3DESTDIR := $(HOME)/.vst3
   JUCE_COPYCMD_VST3 := $(JUCE_OUTDIR)/$(JUCE_VST3DIR) $(JUCE_VST3DESTDIR)
 
-  JUCE_CPPFLAGS_SHARED_CODE :=  "-DJucePlugin_Build_VST=1" "-DJucePlugin_Build_VST3=1" "-DJucePlugin_Build_AU=0" "-DJucePlugin_Build_AUv3=0" "-DJucePlugin_Build_AAX=0" "-DJucePlugin_Build_Standalone=0" "-DJucePlugin_Build_Unity=0" "-DJucePlugin_Build_LV2=0" "-DJUCE_SHARED_CODE=1"
+  JUCE_CPPFLAGS_STANDALONE_PLUGIN :=  "-DJucePlugin_Build_VST=0" "-DJucePlugin_Build_VST3=0" "-DJucePlugin_Build_AU=0" "-DJucePlugin_Build_AUv3=0" "-DJucePlugin_Build_AAX=0" "-DJucePlugin_Build_Standalone=1" "-DJucePlugin_Build_Unity=0" "-DJucePlugin_Build_LV2=0"
+  JUCE_TARGET_STANDALONE_PLUGIN := Signalizer
+
+  JUCE_CPPFLAGS_SHARED_CODE :=  "-DJucePlugin_Build_VST=1" "-DJucePlugin_Build_VST3=1" "-DJucePlugin_Build_AU=0" "-DJucePlugin_Build_AUv3=0" "-DJucePlugin_Build_AAX=0" "-DJucePlugin_Build_Standalone=1" "-DJucePlugin_Build_Unity=0" "-DJucePlugin_Build_LV2=0" "-DJUCE_SHARED_CODE=1"
   JUCE_CFLAGS_SHARED_CODE := -fPIC -fvisibility=hidden
   JUCE_TARGET_SHARED_CODE := Signalizer.a
 
@@ -67,9 +70,9 @@ ifeq ($(CONFIG),Debug)
 
   JUCE_CFLAGS += $(JUCE_CPPFLAGS) $(TARGET_ARCH) -fPIC -g -ggdb -O0 -Wno-ignored-attributes -flax-vector-conversions -DJUCE_MODAL_LOOPS_PERMITTED=1 $(CFLAGS)
   JUCE_CXXFLAGS += $(JUCE_CFLAGS) -std=c++17 $(CXXFLAGS)
-  JUCE_LDFLAGS += $(TARGET_ARCH) -L$(JUCE_BINDIR) -L$(JUCE_LIBDIR) $(shell $(PKG_CONFIG) --libs freetype2 fontconfig gl) -fvisibility=hidden -lrt -ldl -lpthread $(LDFLAGS)
+  JUCE_LDFLAGS += $(TARGET_ARCH) -L$(JUCE_BINDIR) -L$(JUCE_LIBDIR) $(shell $(PKG_CONFIG) --libs alsa freetype2 fontconfig gl) -fvisibility=hidden -lrt -ldl -lpthread $(LDFLAGS)
 
-  CLEANCMD = rm -rf $(JUCE_OUTDIR)/$(JUCE_TARGET_VST) $(JUCE_OUTDIR)/$(JUCE_TARGET_VST3) $(JUCE_OUTDIR)/$(JUCE_TARGET_SHARED_CODE) $(JUCE_OUTDIR)/$(JUCE_TARGET_VST3_MANIFEST_HELPER) $(JUCE_OBJDIR)
+  CLEANCMD = rm -rf $(JUCE_OUTDIR)/$(JUCE_TARGET_VST) $(JUCE_OUTDIR)/$(JUCE_TARGET_VST3) $(JUCE_OUTDIR)/$(JUCE_TARGET_STANDALONE_PLUGIN) $(JUCE_OUTDIR)/$(JUCE_TARGET_SHARED_CODE) $(JUCE_OUTDIR)/$(JUCE_TARGET_VST3_MANIFEST_HELPER) $(JUCE_OBJDIR)
 endif
 
 ifeq ($(CONFIG),Release)
@@ -82,7 +85,7 @@ ifeq ($(CONFIG),Release)
     TARGET_ARCH := 
   endif
 
-  JUCE_CPPFLAGS := $(DEPFLAGS) "-DLINUX=1" "-DNDEBUG=1" "-DCPL_TRACEGUARD_ENTRYPOINTS" "-DJUCER_LINUX_MAKE_6D53C8B4=1" "-DJUCE_APP_VERSION=0.5.0" "-DJUCE_APP_VERSION_HEX=0x500" $(shell $(PKG_CONFIG) --cflags freetype2 fontconfig gl) -pthread -I../../External/juce/modules/juce_audio_processors_headless/format_types/VST3_SDK -I../../../SDKs/vstsdk2.4 -I../../JuceLibraryCode -I../../External/juce/modules -I../../External -I../../Source -I../../Source/Config $(CPPFLAGS)
+  JUCE_CPPFLAGS := $(DEPFLAGS) "-DLINUX=1" "-DNDEBUG=1" "-DCPL_TRACEGUARD_ENTRYPOINTS" "-DJUCER_LINUX_MAKE_6D53C8B4=1" "-DJUCE_APP_VERSION=0.5.0" "-DJUCE_APP_VERSION_HEX=0x500" $(shell $(PKG_CONFIG) --cflags alsa freetype2 fontconfig gl) -pthread -I../../External/juce/modules/juce_audio_processors_headless/format_types/VST3_SDK -I../../../SDKs/vstsdk2.4 -I../../JuceLibraryCode -I../../External/juce/modules -I../../External -I../../Source -I../../Source/Config $(CPPFLAGS)
 
   JUCE_CPPFLAGS_VST :=  "-DJucePlugin_Build_VST=1" "-DJucePlugin_Build_VST3=0" "-DJucePlugin_Build_AU=0" "-DJucePlugin_Build_AUv3=0" "-DJucePlugin_Build_AAX=0" "-DJucePlugin_Build_Standalone=0" "-DJucePlugin_Build_Unity=0" "-DJucePlugin_Build_LV2=0"
   JUCE_CFLAGS_VST := -fPIC -fvisibility=hidden
@@ -101,7 +104,10 @@ ifeq ($(CONFIG),Release)
   JUCE_VST3DESTDIR := $(HOME)/.vst3
   JUCE_COPYCMD_VST3 := $(JUCE_OUTDIR)/$(JUCE_VST3DIR) $(JUCE_VST3DESTDIR)
 
-  JUCE_CPPFLAGS_SHARED_CODE :=  "-DJucePlugin_Build_VST=1" "-DJucePlugin_Build_VST3=1" "-DJucePlugin_Build_AU=0" "-DJucePlugin_Build_AUv3=0" "-DJucePlugin_Build_AAX=0" "-DJucePlugin_Build_Standalone=0" "-DJucePlugin_Build_Unity=0" "-DJucePlugin_Build_LV2=0" "-DJUCE_SHARED_CODE=1"
+  JUCE_CPPFLAGS_STANDALONE_PLUGIN :=  "-DJucePlugin_Build_VST=0" "-DJucePlugin_Build_VST3=0" "-DJucePlugin_Build_AU=0" "-DJucePlugin_Build_AUv3=0" "-DJucePlugin_Build_AAX=0" "-DJucePlugin_Build_Standalone=1" "-DJucePlugin_Build_Unity=0" "-DJucePlugin_Build_LV2=0"
+  JUCE_TARGET_STANDALONE_PLUGIN := Signalizer
+
+  JUCE_CPPFLAGS_SHARED_CODE :=  "-DJucePlugin_Build_VST=1" "-DJucePlugin_Build_VST3=1" "-DJucePlugin_Build_AU=0" "-DJucePlugin_Build_AUv3=0" "-DJucePlugin_Build_AAX=0" "-DJucePlugin_Build_Standalone=1" "-DJucePlugin_Build_Unity=0" "-DJucePlugin_Build_LV2=0" "-DJUCE_SHARED_CODE=1"
   JUCE_CFLAGS_SHARED_CODE := -fPIC -fvisibility=hidden
   JUCE_TARGET_SHARED_CODE := Signalizer.a
 
@@ -110,9 +116,9 @@ ifeq ($(CONFIG),Release)
 
   JUCE_CFLAGS += $(JUCE_CPPFLAGS) $(TARGET_ARCH) -fPIC -O3 -Wno-ignored-attributes -flax-vector-conversions -DJUCE_MODAL_LOOPS_PERMITTED=1 $(CFLAGS)
   JUCE_CXXFLAGS += $(JUCE_CFLAGS) -std=c++17 $(CXXFLAGS)
-  JUCE_LDFLAGS += $(TARGET_ARCH) -L$(JUCE_BINDIR) -L$(JUCE_LIBDIR) $(shell $(PKG_CONFIG) --libs freetype2 fontconfig gl) -fvisibility=hidden -lrt -ldl -lpthread $(LDFLAGS)
+  JUCE_LDFLAGS += $(TARGET_ARCH) -L$(JUCE_BINDIR) -L$(JUCE_LIBDIR) $(shell $(PKG_CONFIG) --libs alsa freetype2 fontconfig gl) -fvisibility=hidden -lrt -ldl -lpthread $(LDFLAGS)
 
-  CLEANCMD = rm -rf $(JUCE_OUTDIR)/$(JUCE_TARGET_VST) $(JUCE_OUTDIR)/$(JUCE_TARGET_VST3) $(JUCE_OUTDIR)/$(JUCE_TARGET_SHARED_CODE) $(JUCE_OUTDIR)/$(JUCE_TARGET_VST3_MANIFEST_HELPER) $(JUCE_OBJDIR)
+  CLEANCMD = rm -rf $(JUCE_OUTDIR)/$(JUCE_TARGET_VST) $(JUCE_OUTDIR)/$(JUCE_TARGET_VST3) $(JUCE_OUTDIR)/$(JUCE_TARGET_STANDALONE_PLUGIN) $(JUCE_OUTDIR)/$(JUCE_TARGET_SHARED_CODE) $(JUCE_OUTDIR)/$(JUCE_TARGET_VST3_MANIFEST_HELPER) $(JUCE_OBJDIR)
 endif
 
 OBJECTS_ALL := \
@@ -122,6 +128,9 @@ OBJECTS_VST := \
 
 OBJECTS_VST3 := \
   $(JUCE_OBJDIR)/include_juce_audio_plugin_client_VST3_dd633589.o \
+
+OBJECTS_STANDALONE_PLUGIN := \
+  $(JUCE_OBJDIR)/include_juce_audio_plugin_client_Standalone_1a871192.o \
 
 OBJECTS_SHARED_CODE := \
   $(JUCE_OBJDIR)/CommonSignalizer_550f1e36.o \
@@ -143,11 +152,14 @@ OBJECTS_SHARED_CODE := \
   $(JUCE_OBJDIR)/VectorscopeRendering_f9996922.o \
   $(JUCE_OBJDIR)/CPLSource_ecbf143b.o \
   $(JUCE_OBJDIR)/include_juce_audio_basics_8a4e984a.o \
+  $(JUCE_OBJDIR)/include_juce_audio_devices_63111d02.o \
+  $(JUCE_OBJDIR)/include_juce_audio_formats_15f82001.o \
   $(JUCE_OBJDIR)/include_juce_audio_plugin_client_ARA_31a052ed.o \
   $(JUCE_OBJDIR)/include_juce_audio_processors_10c03666.o \
   $(JUCE_OBJDIR)/include_juce_audio_processors_headless_1902bafc.o \
   $(JUCE_OBJDIR)/include_juce_audio_processors_headless_ara_8deeb88d.o \
   $(JUCE_OBJDIR)/include_juce_audio_processors_headless_lv2_libs_36180e32.o \
+  $(JUCE_OBJDIR)/include_juce_audio_utils_9f9fb2d6.o \
   $(JUCE_OBJDIR)/include_juce_core_f26d17db.o \
   $(JUCE_OBJDIR)/include_juce_core_CompilationTime_9257742c.o \
   $(JUCE_OBJDIR)/include_juce_data_structures_7471b1e3.o \
@@ -166,18 +178,19 @@ OBJECTS_SHARED_CODE := \
 OBJECTS_VST3_MANIFEST_HELPER := \
   $(JUCE_OBJDIR)/juce_VST3ManifestHelper_118831fa.o \
 
-.PHONY: clean all strip VST VST3 VST3_MANIFEST_HELPER
+.PHONY: clean all strip VST VST3 Standalone VST3_MANIFEST_HELPER
 
-all : VST VST3 VST3_MANIFEST_HELPER
+all : VST VST3 Standalone VST3_MANIFEST_HELPER
 
 VST : $(JUCE_OUTDIR)/$(JUCE_TARGET_VST)
 VST3 : $(JUCE_OUTDIR)/$(JUCE_TARGET_VST3)
+Standalone : $(JUCE_OUTDIR)/$(JUCE_TARGET_STANDALONE_PLUGIN)
 VST3_MANIFEST_HELPER : $(JUCE_OUTDIR)/$(JUCE_TARGET_VST3_MANIFEST_HELPER)
 
 
 $(JUCE_OUTDIR)/$(JUCE_TARGET_VST) : $(OBJECTS_VST) $(JUCE_OBJDIR)/execinfo.cmd $(RESOURCES) $(JUCE_OUTDIR)/$(JUCE_TARGET_SHARED_CODE)
 	@command -v $(PKG_CONFIG) >/dev/null 2>&1 || { echo >&2 "pkg-config not installed. Please, install it."; exit 1; }
-	@$(PKG_CONFIG) --print-errors freetype2 fontconfig gl
+	@$(PKG_CONFIG) --print-errors alsa freetype2 fontconfig gl
 	@echo Linking "Signalizer - VST"
 	-$(V_AT)mkdir -p $(JUCE_BINDIR)
 	-$(V_AT)mkdir -p $(JUCE_LIBDIR)
@@ -187,7 +200,7 @@ $(JUCE_OUTDIR)/$(JUCE_TARGET_VST) : $(OBJECTS_VST) $(JUCE_OBJDIR)/execinfo.cmd $
 
 $(JUCE_OUTDIR)/$(JUCE_TARGET_VST3) : $(OBJECTS_VST3) $(JUCE_OBJDIR)/execinfo.cmd $(RESOURCES) $(JUCE_OUTDIR)/$(JUCE_TARGET_SHARED_CODE) $(JUCE_OUTDIR)/$(JUCE_TARGET_VST3_MANIFEST_HELPER)
 	@command -v $(PKG_CONFIG) >/dev/null 2>&1 || { echo >&2 "pkg-config not installed. Please, install it."; exit 1; }
-	@$(PKG_CONFIG) --print-errors freetype2 fontconfig gl
+	@$(PKG_CONFIG) --print-errors alsa freetype2 fontconfig gl
 	@echo Linking "Signalizer - VST3"
 	-$(V_AT)mkdir -p $(JUCE_BINDIR)
 	-$(V_AT)mkdir -p $(JUCE_LIBDIR)
@@ -199,9 +212,18 @@ $(JUCE_OUTDIR)/$(JUCE_TARGET_VST3) : $(OBJECTS_VST3) $(JUCE_OBJDIR)/execinfo.cmd
 	$(V_AT) $(JUCE_OUTDIR)/$(JUCE_TARGET_VST3_MANIFEST_HELPER) > $(JUCE_OUTDIR)/$(JUCE_VST3DIR)/Contents/Resources/moduleinfo.json
 	-$(V_AT)[ ! "$(JUCE_VST3DESTDIR)" ] || (mkdir -p $(JUCE_VST3DESTDIR) && cp -R $(JUCE_COPYCMD_VST3))
 
+$(JUCE_OUTDIR)/$(JUCE_TARGET_STANDALONE_PLUGIN) : $(OBJECTS_STANDALONE_PLUGIN) $(JUCE_OBJDIR)/execinfo.cmd $(RESOURCES) $(JUCE_OUTDIR)/$(JUCE_TARGET_SHARED_CODE)
+	@command -v $(PKG_CONFIG) >/dev/null 2>&1 || { echo >&2 "pkg-config not installed. Please, install it."; exit 1; }
+	@$(PKG_CONFIG) --print-errors alsa freetype2 fontconfig gl
+	@echo Linking "Signalizer - Standalone Plugin"
+	-$(V_AT)mkdir -p $(JUCE_BINDIR)
+	-$(V_AT)mkdir -p $(JUCE_LIBDIR)
+	-$(V_AT)mkdir -p $(JUCE_OUTDIR)
+	$(V_AT)$(CXX) -o $(JUCE_OUTDIR)/$(JUCE_TARGET_STANDALONE_PLUGIN) $(OBJECTS_STANDALONE_PLUGIN) $(JUCE_OUTDIR)/$(JUCE_TARGET_SHARED_CODE) $(JUCE_LDFLAGS) $(shell cat $(JUCE_OBJDIR)/execinfo.cmd) $(JUCE_LDFLAGS_STANDALONE_PLUGIN) $(RESOURCES) $(TARGET_ARCH)
+
 $(JUCE_OUTDIR)/$(JUCE_TARGET_SHARED_CODE) : $(OBJECTS_SHARED_CODE) $(JUCE_OBJDIR)/execinfo.cmd $(RESOURCES)
 	@command -v $(PKG_CONFIG) >/dev/null 2>&1 || { echo >&2 "pkg-config not installed. Please, install it."; exit 1; }
-	@$(PKG_CONFIG) --print-errors freetype2 fontconfig gl
+	@$(PKG_CONFIG) --print-errors alsa freetype2 fontconfig gl
 	@echo Linking "Signalizer - Shared Code"
 	-$(V_AT)mkdir -p $(JUCE_BINDIR)
 	-$(V_AT)mkdir -p $(JUCE_LIBDIR)
@@ -210,7 +232,7 @@ $(JUCE_OUTDIR)/$(JUCE_TARGET_SHARED_CODE) : $(OBJECTS_SHARED_CODE) $(JUCE_OBJDIR
 
 $(JUCE_OUTDIR)/$(JUCE_TARGET_VST3_MANIFEST_HELPER) : $(OBJECTS_VST3_MANIFEST_HELPER) $(JUCE_OBJDIR)/execinfo.cmd $(RESOURCES) $(JUCE_OUTDIR)/$(JUCE_TARGET_SHARED_CODE) $(JUCE_OBJDIR)/cxxfs.cmd
 	@command -v $(PKG_CONFIG) >/dev/null 2>&1 || { echo >&2 "pkg-config not installed. Please, install it."; exit 1; }
-	@$(PKG_CONFIG) --print-errors freetype2 fontconfig gl
+	@$(PKG_CONFIG) --print-errors alsa freetype2 fontconfig gl
 	@echo Linking "Signalizer - VST3 Manifest Helper"
 	-$(V_AT)mkdir -p $(JUCE_BINDIR)
 	-$(V_AT)mkdir -p $(JUCE_LIBDIR)
@@ -226,6 +248,11 @@ $(JUCE_OBJDIR)/include_juce_audio_plugin_client_VST3_dd633589.o: ../../JuceLibra
 	-$(V_AT)mkdir -p $(@D)
 	@echo "Compiling include_juce_audio_plugin_client_VST3.cpp"
 	$(V_AT)$(CXX) $(JUCE_CXXFLAGS) $(JUCE_CPPFLAGS_VST3) $(JUCE_CFLAGS_VST3) -o "$@" -c "$<"
+
+$(JUCE_OBJDIR)/include_juce_audio_plugin_client_Standalone_1a871192.o: ../../JuceLibraryCode/include_juce_audio_plugin_client_Standalone.cpp
+	-$(V_AT)mkdir -p $(@D)
+	@echo "Compiling include_juce_audio_plugin_client_Standalone.cpp"
+	$(V_AT)$(CXX) $(JUCE_CXXFLAGS) $(JUCE_CPPFLAGS_STANDALONE_PLUGIN) $(JUCE_CFLAGS_STANDALONE_PLUGIN) -o "$@" -c "$<"
 
 $(JUCE_OBJDIR)/CommonSignalizer_550f1e36.o: ../../Source/Common/CommonSignalizer.cpp
 	-$(V_AT)mkdir -p $(@D)
@@ -322,6 +349,16 @@ $(JUCE_OBJDIR)/include_juce_audio_basics_8a4e984a.o: ../../JuceLibraryCode/inclu
 	@echo "Compiling include_juce_audio_basics.cpp"
 	$(V_AT)$(CXX) $(JUCE_CXXFLAGS) $(JUCE_CPPFLAGS_SHARED_CODE) $(JUCE_CFLAGS_SHARED_CODE) -o "$@" -c "$<"
 
+$(JUCE_OBJDIR)/include_juce_audio_devices_63111d02.o: ../../JuceLibraryCode/include_juce_audio_devices.cpp
+	-$(V_AT)mkdir -p $(@D)
+	@echo "Compiling include_juce_audio_devices.cpp"
+	$(V_AT)$(CXX) $(JUCE_CXXFLAGS) $(JUCE_CPPFLAGS_SHARED_CODE) $(JUCE_CFLAGS_SHARED_CODE) -o "$@" -c "$<"
+
+$(JUCE_OBJDIR)/include_juce_audio_formats_15f82001.o: ../../JuceLibraryCode/include_juce_audio_formats.cpp
+	-$(V_AT)mkdir -p $(@D)
+	@echo "Compiling include_juce_audio_formats.cpp"
+	$(V_AT)$(CXX) $(JUCE_CXXFLAGS) $(JUCE_CPPFLAGS_SHARED_CODE) $(JUCE_CFLAGS_SHARED_CODE) -o "$@" -c "$<"
+
 $(JUCE_OBJDIR)/include_juce_audio_plugin_client_ARA_31a052ed.o: ../../JuceLibraryCode/include_juce_audio_plugin_client_ARA.cpp
 	-$(V_AT)mkdir -p $(@D)
 	@echo "Compiling include_juce_audio_plugin_client_ARA.cpp"
@@ -345,6 +382,11 @@ $(JUCE_OBJDIR)/include_juce_audio_processors_headless_ara_8deeb88d.o: ../../Juce
 $(JUCE_OBJDIR)/include_juce_audio_processors_headless_lv2_libs_36180e32.o: ../../JuceLibraryCode/include_juce_audio_processors_headless_lv2_libs.cpp
 	-$(V_AT)mkdir -p $(@D)
 	@echo "Compiling include_juce_audio_processors_headless_lv2_libs.cpp"
+	$(V_AT)$(CXX) $(JUCE_CXXFLAGS) $(JUCE_CPPFLAGS_SHARED_CODE) $(JUCE_CFLAGS_SHARED_CODE) -o "$@" -c "$<"
+
+$(JUCE_OBJDIR)/include_juce_audio_utils_9f9fb2d6.o: ../../JuceLibraryCode/include_juce_audio_utils.cpp
+	-$(V_AT)mkdir -p $(@D)
+	@echo "Compiling include_juce_audio_utils.cpp"
 	$(V_AT)$(CXX) $(JUCE_CXXFLAGS) $(JUCE_CPPFLAGS_SHARED_CODE) $(JUCE_CFLAGS_SHARED_CODE) -o "$@" -c "$<"
 
 $(JUCE_OBJDIR)/include_juce_core_f26d17db.o: ../../JuceLibraryCode/include_juce_core.cpp
@@ -440,9 +482,11 @@ strip:
 	@echo Stripping Signalizer
 	-$(V_AT)$(STRIP) --strip-unneeded $(JUCE_OUTDIR)/$(JUCE_TARGET_VST)
 	-$(V_AT)$(STRIP) --strip-unneeded $(JUCE_OUTDIR)/$(JUCE_TARGET_VST3)
+	-$(V_AT)$(STRIP) --strip-unneeded $(JUCE_OUTDIR)/$(JUCE_TARGET_STANDALONE_PLUGIN)
 	-$(V_AT)$(STRIP) --strip-unneeded $(JUCE_OUTDIR)/$(JUCE_TARGET_VST3_MANIFEST_HELPER)
 
 -include $(OBJECTS_VST:%.o=%.d)
 -include $(OBJECTS_VST3:%.o=%.d)
+-include $(OBJECTS_STANDALONE_PLUGIN:%.o=%.d)
 -include $(OBJECTS_SHARED_CODE:%.o=%.d)
 -include $(OBJECTS_VST3_MANIFEST_HELPER:%.o=%.d)

--- a/Builds/MacOSX/Info-Standalone_Plugin.plist
+++ b/Builds/MacOSX/Info-Standalone_Plugin.plist
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist>
+  <dict>
+    <key>CFBundleExecutable</key>
+    <string>${EXECUTABLE_NAME}</string>
+    <key>CFBundleIconFile</key>
+    <string></string>
+    <key>CFBundleIdentifier</key>
+    <string>com.Lightbridge.Signalizer</string>
+    <key>CFBundleName</key>
+    <string>Signalizer</string>
+    <key>CFBundleDisplayName</key>
+    <string>Signalizer</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleSignature</key>
+    <string>????</string>
+    <key>CFBundleShortVersionString</key>
+    <string>0.5.0</string>
+    <key>CFBundleVersion</key>
+    <string>0.5.0</string>
+    <key>NSHumanReadableCopyright</key>
+    <string></string>
+    <key>NSHighResolutionCapable</key>
+    <true/>
+  </dict>
+</plist>

--- a/Builds/MacOSX/Signalizer.xcodeproj/project.pbxproj
+++ b/Builds/MacOSX/Signalizer.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 				87F651F8FCD734E1DB492CDC,
 				EAB735A0F7E0CCEB15FD4A67,
 				E435B64C8AC143A874E1B00E,
+				8851C41DC080A8C6C4F2FAAC,
 				ADEC07DD26AF35DA4587D624,
 				59BB0F4EB9B3A83AC2A8E2D5,
 			);
@@ -27,8 +28,10 @@
 /* Begin PBXBuildFile section */
 		067393BFEDA793C6D78D2BF2 /* OscilloscopeController.cpp */ = {isa = PBXBuildFile; fileRef = DC09CE5F95D65A93EE43B6C7; };
 		0DAD76EC048AA5FA3B633999 /* IOKit.framework */ = {isa = PBXBuildFile; fileRef = ABA13DCD1D115389BB8181C0; };
+		0FAAB335D814E91FEC26CEDE /* DiscRecording.framework */ = {isa = PBXBuildFile; fileRef = 0806AE937F395D947FF8D260; };
 		1041DD73B19C7DE3CD63FB2F /* Oscilloscope.cpp */ = {isa = PBXBuildFile; fileRef = 9E515EB5EEB6BB943BC9F153; };
 		15EDEC3D65DA21B890E16C38 /* OscilloscopeRendering.cpp */ = {isa = PBXBuildFile; fileRef = F62F6732465E1CE73F15D407; };
+		1896A50280927F7D69DD288D /* include_juce_audio_utils.mm */ = {isa = PBXBuildFile; fileRef = 0A78475D064873F40BD10671; };
 		18B9A29A34FC3E52ACD234BE /* READ ME.txt */ = {isa = PBXBuildFile; fileRef = 4D72676862AF217B4F9EDA8F; };
 		19338070C568ED7658E4C151 /* VectorscopeController.cpp */ = {isa = PBXBuildFile; fileRef = B862795106B01B9775747252; };
 		1A52478FA54133B751049310 /* VST3 */ = {isa = PBXBuildFile; fileRef = 0B31EA8481C14D8A32AF826A; };
@@ -38,6 +41,7 @@
 		2FA62852E140C45A55B35342 /* include_juce_audio_plugin_client_AU_2.mm */ = {isa = PBXBuildFile; fileRef = 294F33BFEBEDA744FF9E88B0; };
 		2FBCDA600AE1B147FD84DC60 /* RecentFilesMenuTemplate.nib */ = {isa = PBXBuildFile; fileRef = C02269DAA7634EF3F4939393; };
 		31B4BDD4E3B845543ACA6F0E /* CPLSource.cpp */ = {isa = PBXBuildFile; fileRef = 9CE2FD789E3B293BA9E81392; };
+		3317994902596EA744998916 /* include_juce_audio_plugin_client_Standalone.cpp */ = {isa = PBXBuildFile; fileRef = 82DBAF7765129C41A411CE24; };
 		354DC8BE341E3237EA68AEF8 /* AudioToolbox.framework */ = {isa = PBXBuildFile; fileRef = 3B2B5B2E2839B6F5BF3F361A; };
 		39F1028137F67BFEAC9CCB27 /* SpectrumController.cpp */ = {isa = PBXBuildFile; fileRef = 7A2AF3F42A04FB47978487E6; };
 		3AA4336158070D601C077899 /* include_juce_gui_extra.mm */ = {isa = PBXBuildFile; fileRef = ABA57AD93D75CC32D075F308; };
@@ -48,6 +52,7 @@
 		54CA7139F0AB53AD65A9314B /* include_juce_audio_processors_headless_lv2_libs.cpp */ = {isa = PBXBuildFile; fileRef = DB33047BEE27309B36D34DDF; };
 		5918D55F86AFFA544CCDDF4F /* SignalizerDesign.cpp */ = {isa = PBXBuildFile; fileRef = 9E55A2B0AEE050B45B716BB7; };
 		5D0FA6346441FE78546DE0EB /* HostGraph.cpp */ = {isa = PBXBuildFile; fileRef = 532E6C813C3550D2494F772A; };
+		5FB7519B7A147B412ABC86EA /* Standalone Plugin */ = {isa = PBXBuildFile; fileRef = CD67A896710111B2ED2E1AD8; };
 		60F6C44E7090A973F232D3D3 /* include_juce_audio_plugin_client_ARA.cpp */ = {isa = PBXBuildFile; fileRef = 4FC05AD8A2F772137F692A46; };
 		655C917F5389DFE750702956 /* MixGraphListener.cpp */ = {isa = PBXBuildFile; fileRef = 34C541BB8907B82F7A22BC4B; };
 		66817EDEABFA450E00069547 /* juce_VST3ManifestHelper.cpp */ = {isa = PBXBuildFile; fileRef = 0BC429AA79B6F25F3A9AFE7E; settings = { COMPILER_FLAGS = "-w -DJUCE_SKIP_PRECOMPILED_HEADER"; }; };
@@ -71,6 +76,7 @@
 		A68E73A7A3370D4EA81B9DED /* SpectrumRendering.cpp */ = {isa = PBXBuildFile; fileRef = 6381774FE90F32C7C6598684; };
 		AA93EEB4270ACC18241B6DDC /* include_juce_audio_processors_headless_ara.cpp */ = {isa = PBXBuildFile; fileRef = 562F0D8856C73D37766DFE60; };
 		AE6BEA798B0198727302C90B /* include_juce_graphics_Sheenbidi.c */ = {isa = PBXBuildFile; fileRef = 7525E648745EFD156E9181D4; };
+		B06519A2542C948F521B9550 /* include_juce_audio_formats.mm */ = {isa = PBXBuildFile; fileRef = 4A6F25670AC04EC403086D09; };
 		B1BCBF3984CC3A18F018DF43 /* resources */ = {isa = PBXBuildFile; fileRef = B1AC63EA11169E0263EA6DF1; };
 		B31F8617916784D220558675 /* include_juce_audio_plugin_client_AU_1.mm */ = {isa = PBXBuildFile; fileRef = EBBAE61197638AE481167BD6; };
 		BCCB1F487D02D7AC9D244293 /* include_juce_events.mm */ = {isa = PBXBuildFile; fileRef = B6734ADF48B95C638D79FBD9; };
@@ -94,6 +100,7 @@
 		ED76225016A53A6AFCD6E24E /* include_juce_gui_basics_5.cpp */ = {isa = PBXBuildFile; fileRef = 3CFFC73C52DD153C98CDA02D; };
 		EF6CB0C164B1BCF764F39135 /* Vectorscope.cpp */ = {isa = PBXBuildFile; fileRef = 58AD876E0679EC3A6DFAE2BF; };
 		F0D4F4C4E8DD69DE154F36BC /* CoreAudio.framework */ = {isa = PBXBuildFile; fileRef = A9560E766C1C7FB37A1B291D; };
+		F443B0F543830710D3583AC5 /* include_juce_audio_devices.mm */ = {isa = PBXBuildFile; fileRef = 3DF22A92B45497CB115A95DE; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -109,6 +116,7 @@
 		07449DDC3CCE3C613481939D /* bench_pffft.c */ /* bench_pffft.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = bench_pffft.c; path = ../../External/cpl/ffts/pffft/bench_pffft.c; sourceTree = SOURCE_ROOT; };
 		075BA8FEB55785235B4C9199 /* pf_double.h */ /* pf_double.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = pf_double.h; path = ../../External/cpl/ffts/pffft/simd/pf_double.h; sourceTree = SOURCE_ROOT; };
 		076944DA717FBDD7C196C55F /* stdext.h */ /* stdext.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = stdext.h; path = ../../External/cpl/stdext.h; sourceTree = SOURCE_ROOT; };
+		0806AE937F395D947FF8D260 /* DiscRecording.framework */ /* DiscRecording.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = DiscRecording.framework; path = System/Library/Frameworks/DiscRecording.framework; sourceTree = SDKROOT; };
 		08747FF622B31A61B3DCD31D /* DisplayOrientationWindows.cpp */ /* DisplayOrientationWindows.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = DisplayOrientationWindows.cpp; path = ../../External/cpl/rendering/DisplayOrientationWindows.cpp; sourceTree = SOURCE_ROOT; };
 		08B349016E749B651533EA23 /* LexicalConversion.h */ /* LexicalConversion.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = LexicalConversion.h; path = ../../External/cpl/LexicalConversion.h; sourceTree = SOURCE_ROOT; };
 		08B7F5BB0DD70DDA5562CC03 /* pffft.h */ /* pffft.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = pffft.h; path = ../../External/cpl/ffts/pffft/pffft.h; sourceTree = SOURCE_ROOT; };
@@ -116,11 +124,13 @@
 		09D4465AED47D21D3BAC0F3F /* pf_scalar_double.h */ /* pf_scalar_double.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = pf_scalar_double.h; path = ../../External/cpl/ffts/pffft/simd/pf_scalar_double.h; sourceTree = SOURCE_ROOT; };
 		0A1735DB869D0AB5C6793E39 /* pf_conv_dispatcher.h */ /* pf_conv_dispatcher.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = pf_conv_dispatcher.h; path = ../../External/cpl/ffts/pffft/pf_conv_dispatcher.h; sourceTree = SOURCE_ROOT; };
 		0A59D9761FC8D619DD5B174A /* ConcurrentConfig.h */ /* ConcurrentConfig.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ConcurrentConfig.h; path = ../../Source/Common/ConcurrentConfig.h; sourceTree = SOURCE_ROOT; };
+		0A78475D064873F40BD10671 /* include_juce_audio_utils.mm */ /* include_juce_audio_utils.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = include_juce_audio_utils.mm; path = ../../JuceLibraryCode/include_juce_audio_utils.mm; sourceTree = SOURCE_ROOT; };
 		0B31EA8481C14D8A32AF826A /* VST3 */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Signalizer.vst3; sourceTree = BUILT_PRODUCTS_DIR; };
 		0B48342DF902EA202C42BC62 /* include_juce_opengl.mm */ /* include_juce_opengl.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = include_juce_opengl.mm; path = ../../JuceLibraryCode/include_juce_opengl.mm; sourceTree = SOURCE_ROOT; };
 		0B89E79EB2153CB79AB16EEB /* CValueKnobSlider.h */ /* CValueKnobSlider.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = CValueKnobSlider.h; path = ../../External/cpl/gui/controls/CValueKnobSlider.h; sourceTree = SOURCE_ROOT; };
 		0BC429AA79B6F25F3A9AFE7E /* juce_VST3ManifestHelper.cpp */ /* juce_VST3ManifestHelper.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = juce_VST3ManifestHelper.cpp; path = ../../External/juce/modules/juce_audio_plugin_client/VST3/juce_VST3ManifestHelper.cpp; sourceTree = SOURCE_ROOT; };
 		0BE20F95E7BEB7758B9D911C /* test_fft_factors.c */ /* test_fft_factors.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = test_fft_factors.c; path = ../../External/cpl/ffts/pffft/test_fft_factors.c; sourceTree = SOURCE_ROOT; };
+		0D8F97EB56E588456062AAC5 /* build.py */ /* build.py */ = {isa = PBXFileReference; lastKnownFileType = file.py; name = build.py; path = ../../build.py; sourceTree = SOURCE_ROOT; };
 		0E2F500BCF853B2F27276087 /* simd_consts.cpp */ /* simd_consts.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = simd_consts.cpp; path = ../../External/cpl/simd/simd_consts.cpp; sourceTree = SOURCE_ROOT; };
 		105AD7E9E8E8B596871F8CDD /* bench_conv.cpp */ /* bench_conv.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = bench_conv.cpp; path = ../../External/cpl/ffts/pffft/bench_conv.cpp; sourceTree = SOURCE_ROOT; };
 		10832DB825B070D3FB6DFAD7 /* test_pffft.cpp */ /* test_pffft.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = test_pffft.cpp; path = ../../External/cpl/ffts/pffft/test_pffft.cpp; sourceTree = SOURCE_ROOT; };
@@ -184,17 +194,20 @@
 		38BE322DF273FBC77E2BBC36 /* DecoupledStateObject.h */ /* DecoupledStateObject.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = DecoupledStateObject.h; path = ../../External/cpl/state/DecoupledStateObject.h; sourceTree = SOURCE_ROOT; };
 		3B0F3C63EDC85C699DD17642 /* CMakeLists.txt */ /* CMakeLists.txt */ = {isa = PBXFileReference; lastKnownFileType = text.txt; name = CMakeLists.txt; path = ../../External/cpl/external/filesystem/CMakeLists.txt; sourceTree = SOURCE_ROOT; };
 		3B2B5B2E2839B6F5BF3F361A /* AudioToolbox.framework */ /* AudioToolbox.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AudioToolbox.framework; path = System/Library/Frameworks/AudioToolbox.framework; sourceTree = SDKROOT; };
+		3BC12EAC3E169A0034838E27 /* juce_audio_utils */ /* juce_audio_utils */ = {isa = PBXFileReference; lastKnownFileType = folder; name = juce_audio_utils; path = ../../External/juce/modules/juce_audio_utils; sourceTree = SOURCE_ROOT; };
 		3C15F90FAC1B602E9505B8C2 /* AudioStream.cpp */ /* AudioStream.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = AudioStream.cpp; path = ../../External/cpl/AudioStream.cpp; sourceTree = SOURCE_ROOT; };
 		3C337D51328B7AC1CBF990DC /* CLIFOStream.h */ /* CLIFOStream.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = CLIFOStream.h; path = ../../External/cpl/lib/CLIFOStream.h; sourceTree = SOURCE_ROOT; };
 		3CB87338DF675CC9106BB6DD /* dustfft.cpp */ /* dustfft.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = dustfft.cpp; path = ../../External/cpl/ffts/dustfft.cpp; sourceTree = SOURCE_ROOT; };
 		3CFFC73C52DD153C98CDA02D /* include_juce_gui_basics_5.cpp */ /* include_juce_gui_basics_5.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = include_juce_gui_basics_5.cpp; path = ../../JuceLibraryCode/include_juce_gui_basics_5.cpp; sourceTree = SOURCE_ROOT; };
 		3D67E0B292A878021EE3C26A /* System.cpp */ /* System.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = System.cpp; path = ../../External/cpl/system/System.cpp; sourceTree = SOURCE_ROOT; };
 		3DAC41FAFB207758CED43478 /* Security.framework */ /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = System/Library/Frameworks/Security.framework; sourceTree = SDKROOT; };
+		3DF22A92B45497CB115A95DE /* include_juce_audio_devices.mm */ /* include_juce_audio_devices.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = include_juce_audio_devices.mm; path = ../../JuceLibraryCode/include_juce_audio_devices.mm; sourceTree = SOURCE_ROOT; };
 		3E09B3F6C07D32877AACE161 /* fs_std_impl.hpp */ /* fs_std_impl.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = fs_std_impl.hpp; path = ../../External/cpl/external/filesystem/include/ghc/fs_std_impl.hpp; sourceTree = SOURCE_ROOT; };
 		3E5D2415A0FEFD9DD52154EF /* DSPWindows.h */ /* DSPWindows.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = DSPWindows.h; path = ../../External/cpl/dsp/DSPWindows.h; sourceTree = SOURCE_ROOT; };
 		3EA641A368AF70E6F0094A12 /* COpenGLImage.h */ /* COpenGLImage.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = COpenGLImage.h; path = ../../External/cpl/rendering/COpenGLImage.h; sourceTree = SOURCE_ROOT; };
 		3EB1DB4B1B11ADAA499D9FEA /* CTransformWidget.h */ /* CTransformWidget.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = CTransformWidget.h; path = ../../External/cpl/gui/widgets/CTransformWidget.h; sourceTree = SOURCE_ROOT; };
 		3FF85AA3304701A3A379E2F1 /* Spectrum.cpp */ /* Spectrum.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = Spectrum.cpp; path = ../../Source/Spectrum/Spectrum.cpp; sourceTree = SOURCE_ROOT; };
+		41A3E9E8A21A9E335C1DCBB9 /* juce_audio_formats */ /* juce_audio_formats */ = {isa = PBXFileReference; lastKnownFileType = folder; name = juce_audio_formats; path = ../../External/juce/modules/juce_audio_formats; sourceTree = SOURCE_ROOT; };
 		41E18E0B5CCEB9FB2DFD14FC /* CComplexResonator.h */ /* CComplexResonator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = CComplexResonator.h; path = ../../External/cpl/dsp/CComplexResonator.h; sourceTree = SOURCE_ROOT; };
 		423BBC0F2CCA37231CABDF8D /* CCtrlEditSpace.h */ /* CCtrlEditSpace.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = CCtrlEditSpace.h; path = ../../External/cpl/gui/CCtrlEditSpace.h; sourceTree = SOURCE_ROOT; };
 		42B2A6D7345F1E5CCC713485 /* CSubpixelSoftwareGraphics.cpp */ /* CSubpixelSoftwareGraphics.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = CSubpixelSoftwareGraphics.cpp; path = ../../External/cpl/rendering/CSubpixelSoftwareGraphics.cpp; sourceTree = SOURCE_ROOT; };
@@ -206,6 +219,7 @@
 		474A2CC4B9563F92F9868A2B /* Exceptions.h */ /* Exceptions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = Exceptions.h; path = ../../External/cpl/Exceptions.h; sourceTree = SOURCE_ROOT; };
 		49C8074A0054E4A1BCE3304C /* CPlistEditor.h */ /* CPlistEditor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = CPlistEditor.h; path = ../../External/cpl/system/CPlistEditor.h; sourceTree = SOURCE_ROOT; };
 		4A0EE3DCD3F5B11FDBDB1F6C /* SampleColourEvaluators.h */ /* SampleColourEvaluators.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SampleColourEvaluators.h; path = ../../Source/Oscilloscope/SampleColourEvaluators.h; sourceTree = SOURCE_ROOT; };
+		4A6F25670AC04EC403086D09 /* include_juce_audio_formats.mm */ /* include_juce_audio_formats.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = include_juce_audio_formats.mm; path = ../../JuceLibraryCode/include_juce_audio_formats.mm; sourceTree = SOURCE_ROOT; };
 		4D72676862AF217B4F9EDA8F /* READ ME.txt */ /* READ ME.txt */ = {isa = PBXFileReference; lastKnownFileType = folder; name = "READ ME.txt"; path = "../../make/Skeleton/READ ME.txt"; sourceTree = "<group>"; };
 		4DA59F299F40C7813F3E4ABC /* CRsrcEditor.h */ /* CRsrcEditor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = CRsrcEditor.h; path = ../../External/cpl/system/CRsrcEditor.h; sourceTree = SOURCE_ROOT; };
 		4DACC98A26D702DD0CFA5ACC /* dir.cpp */ /* dir.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = dir.cpp; path = ../../External/cpl/external/filesystem/examples/dir.cpp; sourceTree = SOURCE_ROOT; };
@@ -304,6 +318,7 @@
 		8078A6DD01691AAE5A60E9A6 /* BlockingLockFreeQueue.h */ /* BlockingLockFreeQueue.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = BlockingLockFreeQueue.h; path = ../../External/cpl/lib/BlockingLockFreeQueue.h; sourceTree = SOURCE_ROOT; };
 		80C4CD34C17CFE7C2A496000 /* ChannelMatrix.h */ /* ChannelMatrix.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ChannelMatrix.h; path = ../../External/cpl/dsp/ChannelMatrix.h; sourceTree = SOURCE_ROOT; };
 		81546767140A69FF4165B727 /* MetalKit.framework */ /* MetalKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MetalKit.framework; path = System/Library/Frameworks/MetalKit.framework; sourceTree = SDKROOT; };
+		82DBAF7765129C41A411CE24 /* include_juce_audio_plugin_client_Standalone.cpp */ /* include_juce_audio_plugin_client_Standalone.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = include_juce_audio_plugin_client_Standalone.cpp; path = ../../JuceLibraryCode/include_juce_audio_plugin_client_Standalone.cpp; sourceTree = SOURCE_ROOT; };
 		839B2132357FCB38DBE2492C /* pf_cic.cpp */ /* pf_cic.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = pf_cic.cpp; path = ../../External/cpl/ffts/pffft/pf_cic.cpp; sourceTree = SOURCE_ROOT; };
 		83DCF14DA9B3D6F2019CAC3C /* WidgetContainers.h */ /* WidgetContainers.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = WidgetContainers.h; path = ../../External/cpl/gui/WidgetContainers.h; sourceTree = SOURCE_ROOT; };
 		84F4C2939C0F253FDC83565E /* GUI.cpp */ /* GUI.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = GUI.cpp; path = ../../External/cpl/gui/GUI.cpp; sourceTree = SOURCE_ROOT; };
@@ -324,11 +339,13 @@
 		8BBA5C0DFF2457C40555CA4A /* SmoothedParameterState.h */ /* SmoothedParameterState.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SmoothedParameterState.h; path = ../../External/cpl/dsp/SmoothedParameterState.h; sourceTree = SOURCE_ROOT; };
 		8BF89D8AE18D9D28B4C3C12D /* CBaseControl.h */ /* CBaseControl.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = CBaseControl.h; path = ../../External/cpl/gui/CBaseControl.h; sourceTree = SOURCE_ROOT; };
 		8C3B1621E7B0F1F13DC3F3CC /* papi_perf_counter.h */ /* papi_perf_counter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = papi_perf_counter.h; path = ../../External/cpl/ffts/pffft/papi_perf_counter.h; sourceTree = SOURCE_ROOT; };
+		8C74957714419573789F6E31 /* Info-Standalone_Plugin.plist */ /* Info-Standalone_Plugin.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "Info-Standalone_Plugin.plist"; path = "Info-Standalone_Plugin.plist"; sourceTree = SOURCE_ROOT; };
 		8C926BCA3748FBF88638D3DD /* octave_signal.h */ /* octave_signal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = octave_signal.h; path = ../../External/cpl/octave/signal/octave_signal.h; sourceTree = SOURCE_ROOT; };
 		8CF4422F8DED9A9FC304886F /* TransformValue.h */ /* TransformValue.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = TransformValue.h; path = ../../External/cpl/infrastructure/values/TransformValue.h; sourceTree = SOURCE_ROOT; };
 		8D1B621B615CDD81C3BF2C4E /* LockFreeDataQueue.h */ /* LockFreeDataQueue.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = LockFreeDataQueue.h; path = ../../External/cpl/lib/LockFreeDataQueue.h; sourceTree = SOURCE_ROOT; };
 		8D55EE8291FF557FFBA1AC0B /* CMakeLists.txt */ /* CMakeLists.txt */ = {isa = PBXFileReference; lastKnownFileType = text.txt; name = CMakeLists.txt; path = ../../External/cpl/ffts/pffft/CMakeLists.txt; sourceTree = SOURCE_ROOT; };
 		8DA537BB13E8A00E9B60406B /* mingw-w64-x64_64.cmake */ /* mingw-w64-x64_64.cmake */ = {isa = PBXFileReference; lastKnownFileType = file.cmake; name = "mingw-w64-x64_64.cmake"; path = "../../External/cpl/ffts/pffft/mingw-w64-x64_64.cmake"; sourceTree = SOURCE_ROOT; };
+		8DD2FC177352FA0D67EA73BE /* prepare.py */ /* prepare.py */ = {isa = PBXFileReference; lastKnownFileType = file.py; name = prepare.py; path = ../../prepare.py; sourceTree = SOURCE_ROOT; };
 		8DF3E33573C349049A1AD3E5 /* SignalizerDesign.h */ /* SignalizerDesign.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SignalizerDesign.h; path = ../../Source/Common/SignalizerDesign.h; sourceTree = SOURCE_ROOT; };
 		8ED957618BA6878230BC21E1 /* DisplayOrientationIOS.cpp */ /* DisplayOrientationIOS.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = DisplayOrientationIOS.cpp; path = ../../External/cpl/rendering/DisplayOrientationIOS.cpp; sourceTree = SOURCE_ROOT; };
 		8F72A3D306924E187E730113 /* build_osx.py */ /* build_osx.py */ = {isa = PBXFileReference; lastKnownFileType = file.py; name = build_osx.py; path = ../../Make/build_osx.py; sourceTree = SOURCE_ROOT; };
@@ -430,12 +447,14 @@
 		CBFAF6C2E4B54CB1A1F6C3A9 /* octave_all.h */ /* octave_all.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = octave_all.h; path = ../../External/cpl/octave/octave_all.h; sourceTree = SOURCE_ROOT; };
 		CC41A135C08D09FF64F80223 /* CToolTip.h */ /* CToolTip.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = CToolTip.h; path = ../../External/cpl/gui/CToolTip.h; sourceTree = SOURCE_ROOT; };
 		CCB2D3CAA7FB69346BEB6811 /* pf_scalar_float.h */ /* pf_scalar_float.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = pf_scalar_float.h; path = ../../External/cpl/ffts/pffft/simd/pf_scalar_float.h; sourceTree = SOURCE_ROOT; };
+		CD67A896710111B2ED2E1AD8 /* Standalone Plugin */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Signalizer.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		CDB3CC2F3E9AFF0C77E3307B /* pf_conv.cpp */ /* pf_conv.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = pf_conv.cpp; path = ../../External/cpl/ffts/pffft/pf_conv.cpp; sourceTree = SOURCE_ROOT; };
 		CECDE50B1BC89CC7CA4F9AA1 /* simd_consts.h */ /* simd_consts.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = simd_consts.h; path = ../../External/cpl/simd/simd_consts.h; sourceTree = SOURCE_ROOT; };
 		CF026F8F592FBB852977DBE4 /* ControlBase.h */ /* ControlBase.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ControlBase.h; path = ../../External/cpl/gui/controls/ControlBase.h; sourceTree = SOURCE_ROOT; };
 		CF18EBD4608C6EFEAEFC58FE /* Misc.h */ /* Misc.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = Misc.h; path = ../../External/cpl/Misc.h; sourceTree = SOURCE_ROOT; };
 		CF7DC83D50D004597D150544 /* pf_sse1_float.h */ /* pf_sse1_float.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = pf_sse1_float.h; path = ../../External/cpl/ffts/pffft/simd/pf_sse1_float.h; sourceTree = SOURCE_ROOT; };
 		D173F521CA7D30245AA79237 /* FormatNormalizers.h */ /* FormatNormalizers.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = FormatNormalizers.h; path = ../../External/cpl/gui/FormatNormalizers.h; sourceTree = SOURCE_ROOT; };
+		D1B29F6472A2A020DD57D8CF /* juce_audio_devices */ /* juce_audio_devices */ = {isa = PBXFileReference; lastKnownFileType = folder; name = juce_audio_devices; path = ../../External/juce/modules/juce_audio_devices; sourceTree = SOURCE_ROOT; };
 		D3907442AC3499A92A6B1645 /* cross_build_mingw64.sh */ /* cross_build_mingw64.sh */ = {isa = PBXFileReference; lastKnownFileType = file.sh; name = cross_build_mingw64.sh; path = ../../External/cpl/ffts/pffft/cross_build_mingw64.sh; sourceTree = SOURCE_ROOT; };
 		D3B1DD37C1580542D4016DCC /* AtomicCompability.h */ /* AtomicCompability.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = AtomicCompability.h; path = ../../External/cpl/AtomicCompability.h; sourceTree = SOURCE_ROOT; };
 		D4C697C5DBD6569F735116C3 /* catch.hpp */ /* catch.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = catch.hpp; path = ../../External/cpl/external/filesystem/test/catch.hpp; sourceTree = SOURCE_ROOT; };
@@ -522,6 +541,7 @@
 				F0D4F4C4E8DD69DE154F36BC,
 				9A7A0328B99302F7C7344E84,
 				71AFB88A89F5508765AE8A9F,
+				0FAAB335D814E91FEC26CEDE,
 				8A397D858ED0145A9DCA0A4B,
 				0DAD76EC048AA5FA3B633999,
 				9ADCF957CAC10F2F084FE271,
@@ -541,7 +561,9 @@
 				354DC8BE341E3237EA68AEF8,
 				E0FF53DDCCA849A6F80E1181,
 				F0D4F4C4E8DD69DE154F36BC,
+				9A7A0328B99302F7C7344E84,
 				71AFB88A89F5508765AE8A9F,
+				0FAAB335D814E91FEC26CEDE,
 				8A397D858ED0145A9DCA0A4B,
 				0DAD76EC048AA5FA3B633999,
 				9ADCF957CAC10F2F084FE271,
@@ -561,7 +583,31 @@
 				354DC8BE341E3237EA68AEF8,
 				E0FF53DDCCA849A6F80E1181,
 				F0D4F4C4E8DD69DE154F36BC,
+				9A7A0328B99302F7C7344E84,
 				71AFB88A89F5508765AE8A9F,
+				0FAAB335D814E91FEC26CEDE,
+				8A397D858ED0145A9DCA0A4B,
+				0DAD76EC048AA5FA3B633999,
+				9ADCF957CAC10F2F084FE271,
+				D67D63216F661725CEB58581,
+				401FCD1272DD51224677EF73,
+				E9C5E25BEDFEE19FA797D0F9,
+				3F377A7FBA80315C82FBC1E3,
+				91CB3D042CDDAA4967FBD55D,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		7F8ED342106DC07363431665 = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				44299907F840D6CF916CABF4,
+				354DC8BE341E3237EA68AEF8,
+				E0FF53DDCCA849A6F80E1181,
+				F0D4F4C4E8DD69DE154F36BC,
+				9A7A0328B99302F7C7344E84,
+				71AFB88A89F5508765AE8A9F,
+				0FAAB335D814E91FEC26CEDE,
 				8A397D858ED0145A9DCA0A4B,
 				0DAD76EC048AA5FA3B633999,
 				9ADCF957CAC10F2F084FE271,
@@ -581,7 +627,9 @@
 				354DC8BE341E3237EA68AEF8,
 				E0FF53DDCCA849A6F80E1181,
 				F0D4F4C4E8DD69DE154F36BC,
+				9A7A0328B99302F7C7344E84,
 				71AFB88A89F5508765AE8A9F,
+				0FAAB335D814E91FEC26CEDE,
 				8A397D858ED0145A9DCA0A4B,
 				0DAD76EC048AA5FA3B633999,
 				9ADCF957CAC10F2F084FE271,
@@ -743,6 +791,7 @@
 				A9560E766C1C7FB37A1B291D,
 				9AD617CE60F603AB73BD1CAC,
 				AD13E79616F5519F01757023,
+				0806AE937F395D947FF8D260,
 				9BD236F0675066E883254F21,
 				ABA13DCD1D115389BB8181C0,
 				DF3EED0643E301A799F6F76D,
@@ -804,15 +853,19 @@
 			children = (
 				33E6785D257C65211213F535,
 				7FC0D3C4FABE440FA5416FDD,
+				3DF22A92B45497CB115A95DE,
+				4A6F25670AC04EC403086D09,
 				4FC05AD8A2F772137F692A46,
 				EBBAE61197638AE481167BD6,
 				294F33BFEBEDA744FF9E88B0,
+				82DBAF7765129C41A411CE24,
 				58F6611349A15E652F66A198,
 				E3D888EE32BB4DC526D34E52,
 				12CF0E46948D3ABC433B415D,
 				D9C9DAAE3B7861E83C047A9A,
 				562F0D8856C73D37766DFE60,
 				DB33047BEE27309B36D34DDF,
+				0A78475D064873F40BD10671,
 				B8EB1459277D4FB2AB5D8CB9,
 				E9FD9B91C11F826DF3636E81,
 				88F37FFB0C08F13F3C211EB7,
@@ -929,12 +982,14 @@
 		6ECC6EAA4542B8FA74216993 /* Build */ = {
 			isa = PBXGroup;
 			children = (
+				0D8F97EB56E588456062AAC5,
 				C1556F1557D1CBCA030D2962,
 				8F72A3D306924E187E730113,
 				542BBA7E0E74677F6A3BBD6B,
 				9737DDF02DCD7A3C56FE6A36,
 				F4667D42FF52C19A5E057D98,
 				FB7FF2D20C6C7A6F651976EB,
+				8DD2FC177352FA0D67EA73BE,
 				E616FE6348B28B43EE7CA516,
 				4ED74E8498D809E9B4B6BC6F,
 			);
@@ -1260,6 +1315,7 @@
 				ABBF01930D4B1AE9E9961BD0,
 				0B31EA8481C14D8A32AF826A,
 				6FFA74F14C822A490902EF08,
+				CD67A896710111B2ED2E1AD8,
 				5E40C6763C0485CA7E9F0B3F,
 				24DD729052BC99D928BFA060,
 			);
@@ -1318,6 +1374,7 @@
 				6418136BB566F3B56B5D95F4,
 				D913D5FD0BC2EA0AED149B15,
 				E954486758F839C99BAA937A,
+				8C74957714419573789F6E31,
 				806432457AC48250D3B807C8,
 				C02269DAA7634EF3F4939393,
 			);
@@ -1375,9 +1432,12 @@
 			isa = PBXGroup;
 			children = (
 				7D4925595BA17402A9F04A45,
+				D1B29F6472A2A020DD57D8CF,
+				41A3E9E8A21A9E335C1DCBB9,
 				BC1B6315AA83A2F873827760,
 				769B31766F610C864045E526,
 				56168B65022B46C0A07DD3D0,
+				3BC12EAC3E169A0034838E27,
 				1B91BF6FE68DA1198AADF41B,
 				9C16D059DBFEDFB0647B073B,
 				79DCAEE818B7923CCAA7299B,
@@ -1452,6 +1512,26 @@
 			productName = Signalizer;
 			productReference = 6FFA74F14C822A490902EF08;
 			productType = "com.apple.product-type.bundle";
+		};
+		A23F184437EBDDDE3B5295DB /* Signalizer - Standalone Plugin */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 6445F33D94303D2029C7F899;
+			buildPhases = (
+				41134CB53C611A0F78461223,
+				F223B71FD695DDBCDB0760C3,
+				7F8ED342106DC07363431665,
+				049559463AB95D8960705C5C,
+				9AA82569357C72C1CC5C88A6,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				2A4514E5925F370E7694FF72,
+			);
+			name = "Signalizer - Standalone Plugin";
+			productName = Signalizer;
+			productReference = CD67A896710111B2ED2E1AD8;
+			productType = "com.apple.product-type.application";
 		};
 		E56D3732117B6977C35DE4DD /* Signalizer - VST */ = {
 			isa = PBXNativeTarget;
@@ -1587,6 +1667,28 @@
 							};
 						};
 					};
+					A23F184437EBDDDE3B5295DB = {
+						SystemCapabilities = {
+							com.apple.ApplicationGroups.iOS = {
+								enabled = 0;
+							};
+							com.apple.HardenedRuntime = {
+								enabled = 0;
+							};
+							com.apple.InAppPurchase = {
+								enabled = 0;
+							};
+							com.apple.InterAppAudio = {
+								enabled = 0;
+							};
+							com.apple.Push = {
+								enabled = 0;
+							};
+							com.apple.Sandbox = {
+								enabled = 0;
+							};
+						};
+					};
 					E56D3732117B6977C35DE4DD = {
 						SystemCapabilities = {
 							com.apple.ApplicationGroups.iOS = {
@@ -1648,6 +1750,7 @@
 				E56D3732117B6977C35DE4DD,
 				7C7BAED18C6045CCF8B87E70,
 				9D28E2775FC0526864ED3B3E,
+				A23F184437EBDDDE3B5295DB,
 				E9F7DD033AA3274115761A11,
 				20B0C2DC40AE29C1AD9B9F27,
 			);
@@ -1679,6 +1782,18 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		41134CB53C611A0F78461223 = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C0C9BD224B00BFEA2F2787C4,
+				8E10BF1F129DBA606C01D784,
+				B1BCBF3984CC3A18F018DF43,
+				18B9A29A34FC3E52ACD234BE,
+				2FBCDA600AE1B147FD84DC60,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		912E43EE06F13A83A923A2A5 = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -1694,6 +1809,17 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		049559463AB95D8960705C5C /* Strip Target */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			name = "Strip Target";
+			alwaysOutOfDate = 1;
+			shellPath = /bin/sh;
+			shellScript = "set -euo pipefail\n\nif [[ \"${CONFIGURATION}\" == \"Release\" ]]; then\n  echo Running strip -x \\\"${BUILT_PRODUCTS_DIR}/${EXECUTABLE_PATH}\\\"\n  strip -x \"${BUILT_PRODUCTS_DIR}/${EXECUTABLE_PATH}\"\nfi\n";
+		};
 		08ED20D3B1CCB5B292139796 /* Sign Target */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -1772,6 +1898,17 @@
 			shellScript = "set -euo pipefail\n\necho Signing Identity:	${EXPANDED_CODE_SIGN_IDENTITY_NAME:-${CODE_SIGN_IDENTITY}}\n\nentitlementsFile=\"${TARGET_TEMP_DIR}/${FULL_PRODUCT_NAME}.xcent\"\n\nif [[ ! -f \"${entitlementsFile}\" ]]; then\n  entitlementsFile=\"\"\nfi\n\necho Entitlements File:	${entitlementsFile:-None}\necho\necho Running codesign --force --sign \\\"${EXPANDED_CODE_SIGN_IDENTITY:-${CODE_SIGN_IDENTITY}}\\\" --verbose=4 --timestamp  ${entitlementsFile:+--entitlements \\\"${entitlementsFile}\\\"} --generate-entitlement-der \\\"${CODESIGNING_FOLDER_PATH}\\\"\ncodesign --force --sign \"${EXPANDED_CODE_SIGN_IDENTITY:-${CODE_SIGN_IDENTITY}}\" --verbose=4 --timestamp  ${entitlementsFile:+--entitlements \"${entitlementsFile}\"} --generate-entitlement-der \"${CODESIGNING_FOLDER_PATH}\"\necho\necho Running codesign --verify --deep --verbose=4 \\\"${CODESIGNING_FOLDER_PATH}\\\"\ncodesign --verify --deep --verbose=4 \"${CODESIGNING_FOLDER_PATH}\"\n";
 		};
 		9986A08C7FFC729ABD7478B7 /* Sign Target */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			name = "Sign Target";
+			alwaysOutOfDate = 1;
+			shellPath = /bin/sh;
+			shellScript = "set -euo pipefail\n\necho Signing Identity:	${EXPANDED_CODE_SIGN_IDENTITY_NAME:-${CODE_SIGN_IDENTITY}}\n\nentitlementsFile=\"${TARGET_TEMP_DIR}/${FULL_PRODUCT_NAME}.xcent\"\n\nif [[ ! -f \"${entitlementsFile}\" ]]; then\n  entitlementsFile=\"\"\nfi\n\necho Entitlements File:	${entitlementsFile:-None}\necho\necho Running codesign --force --sign \\\"${EXPANDED_CODE_SIGN_IDENTITY:-${CODE_SIGN_IDENTITY}}\\\" --verbose=4 --timestamp  ${entitlementsFile:+--entitlements \\\"${entitlementsFile}\\\"} --generate-entitlement-der \\\"${CODESIGNING_FOLDER_PATH}\\\"\ncodesign --force --sign \"${EXPANDED_CODE_SIGN_IDENTITY:-${CODE_SIGN_IDENTITY}}\" --verbose=4 --timestamp  ${entitlementsFile:+--entitlements \"${entitlementsFile}\"} --generate-entitlement-der \"${CODESIGNING_FOLDER_PATH}\"\necho\necho Running codesign --verify --deep --verbose=4 \\\"${CODESIGNING_FOLDER_PATH}\\\"\ncodesign --verify --deep --verbose=4 \"${CODESIGNING_FOLDER_PATH}\"\n";
+		};
+		9AA82569357C72C1CC5C88A6 /* Sign Target */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -1867,11 +2004,14 @@
 				31B4BDD4E3B845543ACA6F0E,
 				A286758C4DBC3F8C295CBEE1,
 				E320BB33B6CDA287A1DA510F,
+				F443B0F543830710D3583AC5,
+				B06519A2542C948F521B9550,
 				60F6C44E7090A973F232D3D3,
 				7A3E5F7350ADC45C342687AE,
 				819C0B284253E87D2F47892F,
 				AA93EEB4270ACC18241B6DDC,
 				54CA7139F0AB53AD65A9314B,
+				1896A50280927F7D69DD288D,
 				47D39DDE6CA9FB3B950CF164,
 				E610F9BF19E7E9717D5BCD44,
 				24925B07C1AA7B6482207E35,
@@ -1897,12 +2037,24 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		F223B71FD695DDBCDB0760C3 = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3317994902596EA744998916,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
 		212BA57989E00836684A0013 = {
 			isa = PBXTargetDependency;
 			target = 20B0C2DC40AE29C1AD9B9F27;
+		};
+		2A4514E5925F370E7694FF72 = {
+			isa = PBXTargetDependency;
+			target = E9F7DD033AA3274115761A11;
 		};
 		59BB0F4EB9B3A83AC2A8E2D5 = {
 			isa = PBXTargetDependency;
@@ -1911,6 +2063,10 @@
 		87F651F8FCD734E1DB492CDC = {
 			isa = PBXTargetDependency;
 			target = E56D3732117B6977C35DE4DD;
+		};
+		8851C41DC080A8C6C4F2FAAC = {
+			isa = PBXTargetDependency;
+			target = A23F184437EBDDDE3B5295DB;
 		};
 		ADEC07DD26AF35DA4587D624 = {
 			isa = PBXTargetDependency;
@@ -2158,7 +2314,7 @@
 					"JucePlugin_Build_AU=1",
 					"JucePlugin_Build_AUv3=0",
 					"JucePlugin_Build_AAX=0",
-					"JucePlugin_Build_Standalone=0",
+					"JucePlugin_Build_Standalone=1",
 					"JucePlugin_Build_Unity=0",
 					"JucePlugin_Build_LV2=0",
 					"JUCE_SHARED_CODE=1",
@@ -2318,6 +2474,66 @@
 			buildSettings = {
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				SDKROOT = macosx;
+			};
+			name = Debug;
+		};
+		9B90F1E191FA2961EE51407C /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "c++17";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_LINK_OBJC_RUNTIME = NO;
+				CODE_SIGN_IDENTITY = "-";
+				CODE_SIGN_STYLE = Manual;
+				COMBINE_HIDPI_IMAGES = YES;
+				CONFIGURATION_BUILD_DIR = "$(PROJECT_DIR)/build/$(CONFIGURATION)";
+				COPY_PHASE_STRIP = NO;
+				DEPLOYMENT_POSTPROCESSING = NO;
+				EXCLUDED_ARCHS = "i386";
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_FAST_MATH = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"_DEBUG=1",
+					"DEBUG=1",
+					"CPL_TRACEGUARD_ENTRYPOINTS",
+					"JUCER_XCODE_MAC_F6D2F4CF=1",
+					"JUCE_APP_VERSION=0.5.0",
+					"JUCE_APP_VERSION_HEX=0x500",
+					"JucePlugin_Build_VST=0",
+					"JucePlugin_Build_VST3=0",
+					"JucePlugin_Build_AU=0",
+					"JucePlugin_Build_AUv3=0",
+					"JucePlugin_Build_AAX=0",
+					"JucePlugin_Build_Standalone=1",
+					"JucePlugin_Build_Unity=0",
+					"JucePlugin_Build_LV2=0",
+				);
+				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
+				HEADER_SEARCH_PATHS = (
+					"$(SRCROOT)/../../External/juce/modules/juce_audio_processors_headless/format_types/VST3_SDK",
+					"$(SRCROOT)/../../../SDKs/vstsdk2.4",
+					"$(SRCROOT)/../../JuceLibraryCode",
+					"$(SRCROOT)/../../External/juce/modules",
+					"$(SRCROOT)/../../External",
+					"$(SRCROOT)/../../Source",
+					"$(SRCROOT)/../../Source/Config",
+					"$(SRCROOT)/../../External/juce/modules/juce_audio_plugin_client/AU",
+					"$(inherited)",
+				);
+				INFOPLIST_FILE = Info-Standalone_Plugin.plist;
+				INFOPLIST_PREPROCESS = NO;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
+				MTL_HEADER_SEARCH_PATHS = "$(SRCROOT)/../../External/juce/modules/juce_audio_processors_headless/format_types/VST3_SDK $(SRCROOT)/../../../SDKs/vstsdk2.4 $(SRCROOT)/../../JuceLibraryCode $(SRCROOT)/../../External/juce/modules $(SRCROOT)/../../External $(SRCROOT)/../../Source $(SRCROOT)/../../Source/Config $(SRCROOT)/../../External/juce/modules/juce_audio_plugin_client/AU";
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_CPLUSPLUSFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = "$(inherited) -lSignalizer";
+				PRODUCT_BUNDLE_IDENTIFIER = com.Lightbridge.Signalizer;
+				PRODUCT_NAME = "Signalizer";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				USE_HEADERMAP = NO;
+				VALIDATE_WORKSPACE_SKIPPED_SDK_FRAMEWORKS = OpenGL;
+				VALID_ARCHS = "arm64 arm64e x86_64";
 			};
 			name = Debug;
 		};
@@ -2591,7 +2807,7 @@
 					"JucePlugin_Build_AU=1",
 					"JucePlugin_Build_AUv3=0",
 					"JucePlugin_Build_AAX=0",
-					"JucePlugin_Build_Standalone=0",
+					"JucePlugin_Build_Standalone=1",
 					"JucePlugin_Build_Unity=0",
 					"JucePlugin_Build_LV2=0",
 					"JUCE_SHARED_CODE=1",
@@ -2691,6 +2907,67 @@
 			};
 			name = Release;
 		};
+		FF007CE9662D3ABCFC446054 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "c++17";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_LINK_OBJC_RUNTIME = NO;
+				CODE_SIGN_IDENTITY = "-";
+				CODE_SIGN_STYLE = Manual;
+				COMBINE_HIDPI_IMAGES = YES;
+				CONFIGURATION_BUILD_DIR = "$(PROJECT_DIR)/build/$(CONFIGURATION)";
+				DEAD_CODE_STRIPPING = YES;
+				DEPLOYMENT_POSTPROCESSING = NO;
+				EXCLUDED_ARCHS = "i386";
+				GCC_FAST_MATH = YES;
+				GCC_GENERATE_DEBUGGING_SYMBOLS = NO;
+				GCC_OPTIMIZATION_LEVEL = s;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"_NDEBUG=1",
+					"NDEBUG=1",
+					"CPL_TRACEGUARD_ENTRYPOINTS",
+					"JUCER_XCODE_MAC_F6D2F4CF=1",
+					"JUCE_APP_VERSION=0.5.0",
+					"JUCE_APP_VERSION_HEX=0x500",
+					"JucePlugin_Build_VST=0",
+					"JucePlugin_Build_VST3=0",
+					"JucePlugin_Build_AU=0",
+					"JucePlugin_Build_AUv3=0",
+					"JucePlugin_Build_AAX=0",
+					"JucePlugin_Build_Standalone=1",
+					"JucePlugin_Build_Unity=0",
+					"JucePlugin_Build_LV2=0",
+				);
+				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
+				HEADER_SEARCH_PATHS = (
+					"$(SRCROOT)/../../External/juce/modules/juce_audio_processors_headless/format_types/VST3_SDK",
+					"$(SRCROOT)/../../../SDKs/vstsdk2.4",
+					"$(SRCROOT)/../../JuceLibraryCode",
+					"$(SRCROOT)/../../External/juce/modules",
+					"$(SRCROOT)/../../External",
+					"$(SRCROOT)/../../Source",
+					"$(SRCROOT)/../../Source/Config",
+					"$(SRCROOT)/../../External/juce/modules/juce_audio_plugin_client/AU",
+					"$(inherited)",
+				);
+				INFOPLIST_FILE = Info-Standalone_Plugin.plist;
+				INFOPLIST_PREPROCESS = NO;
+				LLVM_LTO = YES;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
+				MTL_HEADER_SEARCH_PATHS = "$(SRCROOT)/../../External/juce/modules/juce_audio_processors_headless/format_types/VST3_SDK $(SRCROOT)/../../../SDKs/vstsdk2.4 $(SRCROOT)/../../JuceLibraryCode $(SRCROOT)/../../External/juce/modules $(SRCROOT)/../../External $(SRCROOT)/../../Source $(SRCROOT)/../../Source/Config $(SRCROOT)/../../External/juce/modules/juce_audio_plugin_client/AU";
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_CPLUSPLUSFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = "$(inherited) -lSignalizer";
+				PRODUCT_BUNDLE_IDENTIFIER = com.Lightbridge.Signalizer;
+				PRODUCT_NAME = "Signalizer";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				USE_HEADERMAP = NO;
+				VALIDATE_WORKSPACE_SKIPPED_SDK_FRAMEWORKS = OpenGL;
+				VALID_ARCHS = "arm64 arm64e x86_64";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -2699,6 +2976,15 @@
 			buildConfigurations = (
 				B9B1C50683BEAA19B1143594,
 				A3787B7BD5E0E37CEF9E6D60,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		6445F33D94303D2029C7F899 = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				9B90F1E191FA2961EE51407C,
+				FF007CE9662D3ABCFC446054,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;

--- a/Builds/VisualStudio2022/Signalizer.sln
+++ b/Builds/VisualStudio2022/Signalizer.sln
@@ -2,6 +2,11 @@
 Microsoft Visual Studio Solution File, Format Version 11.00
 # Visual Studio Version 17
 
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Signalizer - Standalone Plugin", "Signalizer_StandalonePlugin.vcxproj", "{1A84B065-5CAA-DD31-87FB-7FE760844AE8}"
+	ProjectSection(ProjectDependencies) = postProject
+		{AA98C3B5-F59A-6D85-E0C4-94F1B8809D3D} = {AA98C3B5-F59A-6D85-E0C4-94F1B8809D3D}
+	EndProjectSection
+EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Signalizer - VST", "Signalizer_VST.vcxproj", "{B5881670-8D8C-E95C-659F-451A4D47E6A7}"
 	ProjectSection(ProjectDependencies) = postProject
 		{AA98C3B5-F59A-6D85-E0C4-94F1B8809D3D} = {AA98C3B5-F59A-6D85-E0C4-94F1B8809D3D}
@@ -31,6 +36,10 @@ Global
 		{E8F37FC0-73CF-D0B7-DE1E-733A8C634D0A}.Debug|x64.Build.0 = Debug|x64
 		{E8F37FC0-73CF-D0B7-DE1E-733A8C634D0A}.Release|x64.ActiveCfg = Release|x64
 		{E8F37FC0-73CF-D0B7-DE1E-733A8C634D0A}.Release|x64.Build.0 = Release|x64
+		{1A84B065-5CAA-DD31-87FB-7FE760844AE8}.Debug|x64.ActiveCfg = Debug|x64
+		{1A84B065-5CAA-DD31-87FB-7FE760844AE8}.Debug|x64.Build.0 = Debug|x64
+		{1A84B065-5CAA-DD31-87FB-7FE760844AE8}.Release|x64.ActiveCfg = Release|x64
+		{1A84B065-5CAA-DD31-87FB-7FE760844AE8}.Release|x64.Build.0 = Release|x64
 		{AA98C3B5-F59A-6D85-E0C4-94F1B8809D3D}.Debug|x64.ActiveCfg = Debug|x64
 		{AA98C3B5-F59A-6D85-E0C4-94F1B8809D3D}.Debug|x64.Build.0 = Debug|x64
 		{AA98C3B5-F59A-6D85-E0C4-94F1B8809D3D}.Release|x64.ActiveCfg = Release|x64

--- a/Builds/VisualStudio2022/Signalizer_SharedCode.vcxproj
+++ b/Builds/VisualStudio2022/Signalizer_SharedCode.vcxproj
@@ -68,7 +68,7 @@
       <Optimization>Disabled</Optimization>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <AdditionalIncludeDirectories>..\..\External\juce\modules\juce_audio_processors_headless\format_types\VST3_SDK;..\..\..\SDKs\vstsdk2.4;..\..\JuceLibraryCode;..\..\External\juce\modules;../../External;../../Source;../../Source/Config;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;_WINDOWS;DEBUG;_DEBUG;JUCE_GUI_BASICS_INCLUDE_SCOPED_THREAD_DPI_AWARENESS_SETTER=1;CPL_TRACEGUARD_ENTRYPOINTS;JUCER_VS2022_78A503E=1;JUCE_APP_VERSION=0.5.0;JUCE_APP_VERSION_HEX=0x500;JucePlugin_Build_VST=1;JucePlugin_Build_VST3=1;JucePlugin_Build_AU=0;JucePlugin_Build_AUv3=0;JucePlugin_Build_AAX=0;JucePlugin_Build_Standalone=0;JucePlugin_Build_Unity=0;JucePlugin_Build_LV2=0;JUCE_SHARED_CODE=1;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;_WINDOWS;DEBUG;_DEBUG;JUCE_GUI_BASICS_INCLUDE_SCOPED_THREAD_DPI_AWARENESS_SETTER=1;CPL_TRACEGUARD_ENTRYPOINTS;JUCER_VS2022_78A503E=1;JUCE_APP_VERSION=0.5.0;JUCE_APP_VERSION_HEX=0x500;JucePlugin_Build_VST=1;JucePlugin_Build_VST3=1;JucePlugin_Build_AU=0;JucePlugin_Build_AUv3=0;JucePlugin_Build_AAX=0;JucePlugin_Build_Standalone=1;JucePlugin_Build_Unity=0;JucePlugin_Build_LV2=0;JUCE_SHARED_CODE=1;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
@@ -83,7 +83,7 @@
     </ClCompile>
     <ResourceCompile>
       <AdditionalIncludeDirectories>..\..\External\juce\modules\juce_audio_processors_headless\format_types\VST3_SDK;..\..\..\SDKs\vstsdk2.4;..\..\JuceLibraryCode;..\..\External\juce\modules;../../External;../../Source;../../Source/Config;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;_WINDOWS;DEBUG;_DEBUG;JUCE_GUI_BASICS_INCLUDE_SCOPED_THREAD_DPI_AWARENESS_SETTER=1;CPL_TRACEGUARD_ENTRYPOINTS;JUCER_VS2022_78A503E=1;JUCE_APP_VERSION=0.5.0;JUCE_APP_VERSION_HEX=0x500;JucePlugin_Build_VST=1;JucePlugin_Build_VST3=1;JucePlugin_Build_AU=0;JucePlugin_Build_AUv3=0;JucePlugin_Build_AAX=0;JucePlugin_Build_Standalone=0;JucePlugin_Build_Unity=0;JucePlugin_Build_LV2=0;JUCE_SHARED_CODE=1;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;_WINDOWS;DEBUG;_DEBUG;JUCE_GUI_BASICS_INCLUDE_SCOPED_THREAD_DPI_AWARENESS_SETTER=1;CPL_TRACEGUARD_ENTRYPOINTS;JUCER_VS2022_78A503E=1;JUCE_APP_VERSION=0.5.0;JUCE_APP_VERSION_HEX=0x500;JucePlugin_Build_VST=1;JucePlugin_Build_VST3=1;JucePlugin_Build_AU=0;JucePlugin_Build_AUv3=0;JucePlugin_Build_AAX=0;JucePlugin_Build_Standalone=1;JucePlugin_Build_Unity=0;JucePlugin_Build_LV2=0;JUCE_SHARED_CODE=1;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ResourceCompile>
     <Link>
       <OutputFile>$(OutDir)\Signalizer.lib</OutputFile>
@@ -100,6 +100,7 @@
     </Bscmake>
     <PostBuildEvent>
       <Command>cp -r ../../Make/Skeleton/* C:\Audio\VSTPlugins\Signalizer
+cp -r ../../Make/Skeleton/* &quot;x64\Debug\Standalone Plugin&quot;
 </Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
@@ -115,7 +116,7 @@
       <Optimization>Full</Optimization>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <AdditionalIncludeDirectories>..\..\External\juce\modules\juce_audio_processors_headless\format_types\VST3_SDK;..\..\..\SDKs\vstsdk2.4;..\..\JuceLibraryCode;..\..\External\juce\modules;../../External;../../Source;../../Source/Config;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;_WINDOWS;NDEBUG;JUCE_GUI_BASICS_INCLUDE_SCOPED_THREAD_DPI_AWARENESS_SETTER=1;CPL_TRACEGUARD_ENTRYPOINTS;JUCER_VS2022_78A503E=1;JUCE_APP_VERSION=0.5.0;JUCE_APP_VERSION_HEX=0x500;JucePlugin_Build_VST=1;JucePlugin_Build_VST3=1;JucePlugin_Build_AU=0;JucePlugin_Build_AUv3=0;JucePlugin_Build_AAX=0;JucePlugin_Build_Standalone=0;JucePlugin_Build_Unity=0;JucePlugin_Build_LV2=0;JUCE_SHARED_CODE=1;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;_WINDOWS;NDEBUG;JUCE_GUI_BASICS_INCLUDE_SCOPED_THREAD_DPI_AWARENESS_SETTER=1;CPL_TRACEGUARD_ENTRYPOINTS;JUCER_VS2022_78A503E=1;JUCE_APP_VERSION=0.5.0;JUCE_APP_VERSION_HEX=0x500;JucePlugin_Build_VST=1;JucePlugin_Build_VST3=1;JucePlugin_Build_AU=0;JucePlugin_Build_AUv3=0;JucePlugin_Build_AAX=0;JucePlugin_Build_Standalone=1;JucePlugin_Build_Unity=0;JucePlugin_Build_LV2=0;JUCE_SHARED_CODE=1;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
@@ -130,7 +131,7 @@
     </ClCompile>
     <ResourceCompile>
       <AdditionalIncludeDirectories>..\..\External\juce\modules\juce_audio_processors_headless\format_types\VST3_SDK;..\..\..\SDKs\vstsdk2.4;..\..\JuceLibraryCode;..\..\External\juce\modules;../../External;../../Source;../../Source/Config;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;_WINDOWS;NDEBUG;JUCE_GUI_BASICS_INCLUDE_SCOPED_THREAD_DPI_AWARENESS_SETTER=1;CPL_TRACEGUARD_ENTRYPOINTS;JUCER_VS2022_78A503E=1;JUCE_APP_VERSION=0.5.0;JUCE_APP_VERSION_HEX=0x500;JucePlugin_Build_VST=1;JucePlugin_Build_VST3=1;JucePlugin_Build_AU=0;JucePlugin_Build_AUv3=0;JucePlugin_Build_AAX=0;JucePlugin_Build_Standalone=0;JucePlugin_Build_Unity=0;JucePlugin_Build_LV2=0;JUCE_SHARED_CODE=1;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;_WINDOWS;NDEBUG;JUCE_GUI_BASICS_INCLUDE_SCOPED_THREAD_DPI_AWARENESS_SETTER=1;CPL_TRACEGUARD_ENTRYPOINTS;JUCER_VS2022_78A503E=1;JUCE_APP_VERSION=0.5.0;JUCE_APP_VERSION_HEX=0x500;JucePlugin_Build_VST=1;JucePlugin_Build_VST3=1;JucePlugin_Build_AU=0;JucePlugin_Build_AUv3=0;JucePlugin_Build_AAX=0;JucePlugin_Build_Standalone=1;JucePlugin_Build_Unity=0;JucePlugin_Build_LV2=0;JUCE_SHARED_CODE=1;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ResourceCompile>
     <Link>
       <OutputFile>$(OutDir)\Signalizer.lib</OutputFile>
@@ -150,6 +151,7 @@
     </Bscmake>
     <PostBuildEvent>
       <Command>cp -r ../../Make/Skeleton/* C:\Audio\VSTPlugins\Signalizer
+cp -r ../../Make/Skeleton/* &quot;x64\Release\Standalone Plugin&quot;
 </Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
@@ -571,6 +573,480 @@
     <ClCompile Include="..\..\External\juce\modules\juce_audio_basics\juce_audio_basics.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\audio_io\juce_AudioDeviceManager.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\audio_io\juce_AudioIODevice.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\audio_io\juce_AudioIODeviceType.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\audio_io\juce_SampleRateHelpers.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\midi_io\ump\juce_UMPBlock.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\midi_io\ump\juce_UMPEndpointId.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\midi_io\ump\juce_UMPEndpoints.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\midi_io\ump\juce_UMPInput.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\midi_io\ump\juce_UMPIOHelpers.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\midi_io\ump\juce_UMPLegacyVirtualInput.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\midi_io\ump\juce_UMPLegacyVirtualOutput.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\midi_io\ump\juce_UMPOutput.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\midi_io\ump\juce_UMPSession.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\midi_io\ump\juce_UMPVirtualEndpoint.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\midi_io\juce_MidiDeviceListConnectionBroadcaster.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\midi_io\juce_MidiDevices.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\midi_io\juce_MidiMessageCollector.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\midi_io\juce_WaitFreeListeners.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\aaudio\AAudioLoader.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\aaudio\AudioStreamAAudio.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\common\AdpfWrapper.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\common\AudioSourceCaller.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\common\AudioStream.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\common\AudioStreamBuilder.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\common\DataConversionFlowGraph.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\common\FilterAudioStream.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\common\FixedBlockAdapter.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\common\FixedBlockReader.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\common\FixedBlockWriter.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\common\LatencyTuner.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\common\OboeExtensions.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\common\QuirksManager.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\common\SourceFloatCaller.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\common\SourceI16Caller.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\common\SourceI24Caller.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\common\SourceI32Caller.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\common\StabilizedCallback.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\common\Trace.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\common\Utilities.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\common\Version.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\fifo\FifoBuffer.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\fifo\FifoController.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\fifo\FifoControllerBase.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\fifo\FifoControllerIndirect.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\resampler\IntegerRatio.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\resampler\LinearResampler.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\resampler\MultiChannelResampler.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\resampler\PolyphaseResampler.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\resampler\PolyphaseResamplerMono.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\resampler\PolyphaseResamplerStereo.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\resampler\SincResampler.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\resampler\SincResamplerStereo.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\ChannelCountConverter.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\ClipToRange.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\FlowGraphNode.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\Limiter.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\ManyToMultiConverter.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\MonoBlend.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\MonoToMultiConverter.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\MultiToManyConverter.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\MultiToMonoConverter.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\RampLinear.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\SampleRateConverter.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\SinkFloat.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\SinkI8_24.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\SinkI16.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\SinkI24.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\SinkI32.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\SourceFloat.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\SourceI8_24.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\SourceI16.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\SourceI24.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\SourceI32.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\opensles\AudioInputStreamOpenSLES.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\opensles\AudioOutputStreamOpenSLES.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\opensles\AudioStreamBuffered.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\opensles\AudioStreamOpenSLES.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\opensles\EngineOpenSLES.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\opensles\OpenSLESUtilities.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\opensles\OutputMixerOpenSLES.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\juce_ALSA_linux.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\juce_ASIO_windows.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\juce_Audio_android.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\juce_Audio_ios.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\juce_CoreAudio_mac.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\juce_DirectSound_windows.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\juce_JackAudio.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\juce_Midi_android.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\juce_Midi_linux.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\juce_Midi_windows.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\juce_Oboe_android.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\juce_OpenSL_android.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\juce_WASAPI_windows.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\sources\juce_AudioSourcePlayer.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\sources\juce_AudioTransportSource.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\juce_audio_devices.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\codecs\flac\libFLAC\deduplication\bitreader_read_rice_signed_block.c">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\codecs\flac\libFLAC\deduplication\lpc_compute_autocorrelation_intrin.c">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\codecs\flac\libFLAC\deduplication\lpc_compute_autocorrelation_intrin_neon.c">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\codecs\flac\libFLAC\bitmath.c">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\codecs\flac\libFLAC\bitreader.c">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\codecs\flac\libFLAC\bitwriter.c">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\codecs\flac\libFLAC\cpu.c">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\codecs\flac\libFLAC\crc.c">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\codecs\flac\libFLAC\fixed.c">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\codecs\flac\libFLAC\float.c">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\codecs\flac\libFLAC\format.c">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\codecs\flac\libFLAC\lpc_flac.c">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\codecs\flac\libFLAC\lpc_intrin_neon.c">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\codecs\flac\libFLAC\md5.c">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\codecs\flac\libFLAC\memory.c">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\codecs\flac\libFLAC\stream_decoder.c">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\codecs\flac\libFLAC\stream_encoder.c">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\codecs\flac\libFLAC\stream_encoder_framing.c">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\codecs\flac\libFLAC\window_flac.c">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\analysis.c">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\bitrate.c">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\block.c">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\codebook.c">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\envelope.c">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\floor0.c">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\floor1.c">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\info.c">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\lookup.c">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\lpc.c">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\lsp.c">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\mapping0.c">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\mdct.c">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\misc.c">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\psy.c">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\registry.c">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\res0.c">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\sharedbook.c">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\smallft.c">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\synthesis.c">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\vorbisenc.c">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\vorbisfile.c">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\window.c">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\bitwise.c">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\framing.c">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\codecs\juce_AiffAudioFormat.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\codecs\juce_CoreAudioFormat.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\codecs\juce_FlacAudioFormat.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\codecs\juce_LAMEEncoderAudioFormat.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\codecs\juce_MP3AudioFormat.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\codecs\juce_OggVorbisAudioFormat.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\codecs\juce_WavAudioFormat.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\codecs\juce_WindowsMediaAudioFormat.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\format\juce_ARAAudioReaders.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\format\juce_AudioFormat.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\format\juce_AudioFormatManager.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\format\juce_AudioFormatReader.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\format\juce_AudioFormatReaderSource.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\format\juce_AudioFormatWriter.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\format\juce_AudioSubsectionReader.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\format\juce_BufferingAudioFormatReader.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\sampler\juce_Sampler.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\juce_audio_formats.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="..\..\External\juce\modules\juce_audio_plugin_client\juce_audio_plugin_client_ARA.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
@@ -929,6 +1405,60 @@
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="..\..\External\juce\modules\juce_audio_processors_headless\juce_audio_processors_headless_lv2_libs.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_utils\audio_cd\juce_AudioCDReader.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_utils\gui\juce_AudioAppComponent.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_utils\gui\juce_AudioDeviceSelectorComponent.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_utils\gui\juce_AudioThumbnail.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_utils\gui\juce_AudioThumbnailCache.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_utils\gui\juce_AudioVisualiserComponent.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_utils\gui\juce_KeyboardComponentBase.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_utils\gui\juce_MidiKeyboardComponent.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_utils\gui\juce_MPEKeyboardComponent.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_utils\native\juce_AudioCDBurner_windows.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_utils\native\juce_AudioCDReader_linux.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_utils\native\juce_AudioCDReader_windows.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_utils\native\juce_BluetoothMidiDevicePairingDialogue_android.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_utils\native\juce_BluetoothMidiDevicePairingDialogue_linux.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_utils\native\juce_BluetoothMidiDevicePairingDialogue_windows.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_utils\players\juce_AudioProcessorPlayer.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_utils\players\juce_SoundPlayer.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_utils\juce_audio_utils.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="..\..\External\juce\modules\juce_core\containers\juce_AbstractFifo.cpp">
@@ -2675,6 +3205,8 @@
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="..\..\JuceLibraryCode\include_juce_audio_basics.cpp"/>
+    <ClCompile Include="..\..\JuceLibraryCode\include_juce_audio_devices.cpp"/>
+    <ClCompile Include="..\..\JuceLibraryCode\include_juce_audio_formats.cpp"/>
     <ClCompile Include="..\..\JuceLibraryCode\include_juce_audio_plugin_client_ARA.cpp"/>
     <ClCompile Include="..\..\JuceLibraryCode\include_juce_audio_processors.cpp">
       <AdditionalOptions> /bigobj %(AdditionalOptions)</AdditionalOptions>
@@ -2684,6 +3216,7 @@
     </ClCompile>
     <ClCompile Include="..\..\JuceLibraryCode\include_juce_audio_processors_headless_ara.cpp"/>
     <ClCompile Include="..\..\JuceLibraryCode\include_juce_audio_processors_headless_lv2_libs.cpp"/>
+    <ClCompile Include="..\..\JuceLibraryCode\include_juce_audio_utils.cpp"/>
     <ClCompile Include="..\..\JuceLibraryCode\include_juce_core.cpp">
       <AdditionalOptions> /bigobj %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
@@ -2979,6 +3512,209 @@
     <ClInclude Include="..\..\External\juce\modules\juce_audio_basics\utilities\juce_Reverb.h"/>
     <ClInclude Include="..\..\External\juce\modules\juce_audio_basics\utilities\juce_SmoothedValue.h"/>
     <ClInclude Include="..\..\External\juce\modules\juce_audio_basics\juce_audio_basics.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\audio_io\juce_AudioDeviceManager.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\audio_io\juce_AudioIODevice.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\audio_io\juce_AudioIODeviceType.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\audio_io\juce_SystemAudioVolume.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\midi_io\ump\juce_UMPBlock.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\midi_io\ump\juce_UMPDisconnectionListener.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\midi_io\ump\juce_UMPEndpoint.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\midi_io\ump\juce_UMPEndpointId.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\midi_io\ump\juce_UMPEndpoints.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\midi_io\ump\juce_UMPInput.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\midi_io\ump\juce_UMPLegacyVirtualInput.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\midi_io\ump\juce_UMPLegacyVirtualOutput.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\midi_io\ump\juce_UMPOutput.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\midi_io\ump\juce_UMPSession.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\midi_io\ump\juce_UMPStaticDeviceInfo.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\midi_io\ump\juce_UMPVirtualEndpoint.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\midi_io\juce_MidiDevices.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\midi_io\juce_MidiMessageCollector.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\midi_io\juce_ScheduledEventThread.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\midi_io\juce_WaitFreeListeners.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\asio\asio.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\asio\asiosys.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\asio\iasiodrv.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\include\oboe\AudioStream.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\include\oboe\AudioStreamBase.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\include\oboe\AudioStreamBuilder.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\include\oboe\AudioStreamCallback.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\include\oboe\Definitions.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\include\oboe\FifoBuffer.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\include\oboe\FifoControllerBase.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\include\oboe\FullDuplexStream.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\include\oboe\LatencyTuner.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\include\oboe\Oboe.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\include\oboe\OboeExtensions.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\include\oboe\ResultWithValue.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\include\oboe\StabilizedCallback.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\include\oboe\Utilities.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\include\oboe\Version.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\aaudio\AAudioExtensions.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\aaudio\AAudioLoader.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\aaudio\AudioStreamAAudio.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\common\AdpfWrapper.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\common\AudioClock.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\common\AudioSourceCaller.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\common\DataConversionFlowGraph.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\common\FilterAudioStream.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\common\FixedBlockAdapter.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\common\FixedBlockReader.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\common\FixedBlockWriter.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\common\MonotonicCounter.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\common\OboeDebug.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\common\QuirksManager.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\common\SourceFloatCaller.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\common\SourceI16Caller.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\common\SourceI24Caller.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\common\SourceI32Caller.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\common\Trace.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\fifo\FifoController.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\fifo\FifoControllerIndirect.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\resampler\HyperbolicCosineWindow.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\resampler\IntegerRatio.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\resampler\KaiserWindow.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\resampler\LinearResampler.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\resampler\MultiChannelResampler.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\resampler\PolyphaseResampler.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\resampler\PolyphaseResamplerMono.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\resampler\PolyphaseResamplerStereo.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\resampler\ResamplerDefinitions.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\resampler\SincResampler.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\resampler\SincResamplerStereo.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\ChannelCountConverter.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\ClipToRange.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\FlowGraphNode.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\FlowgraphUtilities.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\Limiter.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\ManyToMultiConverter.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\MonoBlend.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\MonoToMultiConverter.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\MultiToManyConverter.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\MultiToMonoConverter.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\RampLinear.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\SampleRateConverter.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\SinkFloat.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\SinkI8_24.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\SinkI16.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\SinkI24.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\SinkI32.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\SourceFloat.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\SourceI8_24.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\SourceI16.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\SourceI24.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\SourceI32.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\opensles\AudioInputStreamOpenSLES.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\opensles\AudioOutputStreamOpenSLES.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\opensles\AudioStreamBuffered.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\opensles\AudioStreamOpenSLES.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\opensles\EngineOpenSLES.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\opensles\OpenSLESUtilities.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\opensles\OutputMixerOpenSLES.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\juce_ALSA_weak_linux.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\juce_Audio_ios.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\juce_HighPerformanceAudioHelpers_android.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\sources\juce_AudioSourcePlayer.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\sources\juce_AudioTransportSource.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\juce_audio_devices.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\flac\libFLAC\include\private\bitmath.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\flac\libFLAC\include\private\bitreader.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\flac\libFLAC\include\private\bitwriter.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\flac\libFLAC\include\private\cpu.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\flac\libFLAC\include\private\crc.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\flac\libFLAC\include\private\fixed.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\flac\libFLAC\include\private\float.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\flac\libFLAC\include\private\format.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\flac\libFLAC\include\private\lpc.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\flac\libFLAC\include\private\md5.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\flac\libFLAC\include\private\memory.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\flac\libFLAC\include\private\stream_encoder.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\flac\libFLAC\include\private\stream_encoder_framing.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\flac\libFLAC\include\private\window.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\flac\libFLAC\include\protected\stream_decoder.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\flac\libFLAC\include\protected\stream_encoder.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\flac\all.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\flac\alloc.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\flac\assert.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\flac\callback.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\flac\compat.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\flac\endswap.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\flac\export.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\flac\format.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\flac\metadata.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\flac\ordinals.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\flac\private.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\flac\stream_decoder.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\flac\stream_encoder.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\books\coupled\res_books_51.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\books\coupled\res_books_stereo.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\books\floor\floor_books.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\books\uncoupled\res_books_uncoupled.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\modes\floor_all.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\modes\psych_8.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\modes\psych_11.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\modes\psych_16.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\modes\psych_44.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\modes\residue_8.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\modes\residue_16.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\modes\residue_44.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\modes\residue_44p51.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\modes\residue_44u.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\modes\setup_8.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\modes\setup_11.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\modes\setup_16.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\modes\setup_22.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\modes\setup_32.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\modes\setup_44.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\modes\setup_44p51.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\modes\setup_44u.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\modes\setup_X.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\backends.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\bitrate.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\codebook.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\codec_internal.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\envelope.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\highlevel.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\lookup.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\lookup_data.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\lpc.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\lsp.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\masking.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\mdct.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\misc.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\os.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\psy.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\registry.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\scales.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\smallft.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\window.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\codec.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\config_types.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\crctable.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\ogg.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\os_types.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\vorbisenc.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\vorbisfile.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\juce_AiffAudioFormat.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\juce_CoreAudioFormat.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\juce_FlacAudioFormat.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\juce_LAMEEncoderAudioFormat.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\juce_MP3AudioFormat.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\juce_OggVorbisAudioFormat.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\juce_WavAudioFormat.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\juce_WindowsMediaAudioFormat.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\format\juce_ARAAudioReaders.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\format\juce_AudioFormat.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\format\juce_AudioFormatManager.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\format\juce_AudioFormatReader.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\format\juce_AudioFormatReaderSource.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\format\juce_AudioFormatWriter.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\format\juce_AudioFormatWriterOptions.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\format\juce_AudioSubsectionReader.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\format\juce_BufferingAudioFormatReader.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\format\juce_MemoryMappedAudioFormatReader.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\sampler\juce_Sampler.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\juce_audio_formats.h"/>
     <ClInclude Include="..\..\External\juce\modules\juce_audio_plugin_client\detail\juce_CheckSettingMacros.h"/>
     <ClInclude Include="..\..\External\juce\modules\juce_audio_plugin_client\detail\juce_CreatePluginFilter.h"/>
     <ClInclude Include="..\..\External\juce\modules\juce_audio_plugin_client\detail\juce_IncludeModuleHeaders.h"/>
@@ -3211,6 +3947,21 @@
     <ClInclude Include="..\..\External\juce\modules\juce_audio_processors_headless\utilities\juce_VST3ClientExtensions.h"/>
     <ClInclude Include="..\..\External\juce\modules\juce_audio_processors_headless\utilities\juce_VST3Interface.h"/>
     <ClInclude Include="..\..\External\juce\modules\juce_audio_processors_headless\juce_audio_processors_headless.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_utils\audio_cd\juce_AudioCDBurner.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_utils\audio_cd\juce_AudioCDReader.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_utils\gui\juce_AudioAppComponent.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_utils\gui\juce_AudioDeviceSelectorComponent.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_utils\gui\juce_AudioThumbnail.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_utils\gui\juce_AudioThumbnailBase.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_utils\gui\juce_AudioThumbnailCache.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_utils\gui\juce_AudioVisualiserComponent.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_utils\gui\juce_BluetoothMidiDevicePairingDialogue.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_utils\gui\juce_KeyboardComponentBase.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_utils\gui\juce_MidiKeyboardComponent.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_utils\gui\juce_MPEKeyboardComponent.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_utils\players\juce_AudioProcessorPlayer.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_utils\players\juce_SoundPlayer.h"/>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_utils\juce_audio_utils.h"/>
     <ClInclude Include="..\..\External\juce\modules\juce_core\containers\juce_AbstractFifo.h"/>
     <ClInclude Include="..\..\External\juce\modules\juce_core\containers\juce_Array.h"/>
     <ClInclude Include="..\..\External\juce\modules\juce_core\containers\juce_ArrayAllocationBase.h"/>
@@ -4074,12 +4825,14 @@
     <ClInclude Include="..\..\JuceLibraryCode\JucePluginDefines.h"/>
   </ItemGroup>
   <ItemGroup>
+    <None Include="..\..\build.py"/>
     <None Include="..\..\Make\build_linux.py"/>
     <None Include="..\..\Make\build_osx.py"/>
     <None Include="..\..\Make\build_win.py"/>
     <None Include="..\..\Make\common.py"/>
     <None Include="..\..\Make\config.ini"/>
     <None Include="..\..\Make\macos_installation_advice.txt"/>
+    <None Include="..\..\prepare.py"/>
     <None Include="..\..\Make\vscompile.bat"/>
     <None Include="..\..\Make\windows_installation_advice.txt"/>
     <None Include="..\..\External\cpl\external\filesystem\cmake\config.cmake.in"/>
@@ -4102,6 +4855,15 @@
     <None Include="..\..\External\cpl\ffts\pffft\use_gcc8.inc"/>
     <None Include="..\..\External\cpl\lib\readerwriterqueue\license.txt"/>
     <None Include="..\..\Source\Notes\Bugs.txt"/>
+    <None Include="..\..\External\juce\modules\juce_audio_devices\native\asio\LICENSE.txt"/>
+    <None Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\common\README.md"/>
+    <None Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\resampler\README.md"/>
+    <None Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\CMakeLists.txt"/>
+    <None Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\README.md"/>
+    <None Include="..\..\External\juce\modules\juce_audio_formats\codecs\flac\Flac Licence.txt"/>
+    <None Include="..\..\External\juce\modules\juce_audio_formats\codecs\flac\JUCE_CHANGES.txt"/>
+    <None Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\README.md"/>
+    <None Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\Ogg Vorbis Licence.txt"/>
     <None Include="..\..\External\juce\modules\juce_audio_processors_headless\format_types\LV2_SDK\README.md"/>
     <None Include="..\..\External\juce\modules\juce_audio_processors_headless\format_types\VST3_SDK\base\LICENSE.txt"/>
     <None Include="..\..\External\juce\modules\juce_audio_processors_headless\format_types\VST3_SDK\base\README.md"/>

--- a/Builds/VisualStudio2022/Signalizer_SharedCode.vcxproj.filters
+++ b/Builds/VisualStudio2022/Signalizer_SharedCode.vcxproj.filters
@@ -158,6 +158,111 @@
     <Filter Include="JUCE Modules\juce_audio_basics">
       <UniqueIdentifier>{10472B2C-9888-D269-F351-0D0AC3BCD16C}</UniqueIdentifier>
     </Filter>
+    <Filter Include="JUCE Modules\juce_audio_devices\audio_io">
+      <UniqueIdentifier>{BF23FC10-1D57-2A9B-706F-6DD8A7B593D4}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="JUCE Modules\juce_audio_devices\midi_io\ump">
+      <UniqueIdentifier>{386862D5-4DCC-A4B3-5642-60A201E303EF}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="JUCE Modules\juce_audio_devices\midi_io">
+      <UniqueIdentifier>{092EFC17-7C95-7E04-0ACA-0D61A462EE81}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="JUCE Modules\juce_audio_devices\native\asio">
+      <UniqueIdentifier>{9DEBE9A8-0B63-A378-E790-66C382DC8010}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="JUCE Modules\juce_audio_devices\native\oboe\include\oboe">
+      <UniqueIdentifier>{285118C6-8FDA-7DCE-BEF4-FFB2120876C5}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="JUCE Modules\juce_audio_devices\native\oboe\include">
+      <UniqueIdentifier>{69ED6B61-9B8D-D47E-E4A6-2E9F9A94A75A}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="JUCE Modules\juce_audio_devices\native\oboe\src\aaudio">
+      <UniqueIdentifier>{7CDB7CD1-BB96-F593-3C78-1E06182B5839}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="JUCE Modules\juce_audio_devices\native\oboe\src\common">
+      <UniqueIdentifier>{B0A708DE-B4CF-196B-14FB-DC8221509B8E}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="JUCE Modules\juce_audio_devices\native\oboe\src\fifo">
+      <UniqueIdentifier>{34F46ADE-EE31-227A-A69E-7732E70145F1}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="JUCE Modules\juce_audio_devices\native\oboe\src\flowgraph\resampler">
+      <UniqueIdentifier>{BB9B3C77-17FB-E994-8B75-88F1727E4655}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="JUCE Modules\juce_audio_devices\native\oboe\src\flowgraph">
+      <UniqueIdentifier>{C0971D77-2F14-190A-E2AE-89D6285F4D5A}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="JUCE Modules\juce_audio_devices\native\oboe\src\opensles">
+      <UniqueIdentifier>{AABEA333-6524-8891-51C7-6DAEB5700628}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="JUCE Modules\juce_audio_devices\native\oboe\src">
+      <UniqueIdentifier>{F2D29337-983E-BAD7-7B5C-E0AB3D53D404}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="JUCE Modules\juce_audio_devices\native\oboe">
+      <UniqueIdentifier>{C674B0FB-1FC0-2986-94B1-083845018994}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="JUCE Modules\juce_audio_devices\native">
+      <UniqueIdentifier>{0AFC1CE8-F6E6-9817-8C21-8432B2A375DA}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="JUCE Modules\juce_audio_devices\sources">
+      <UniqueIdentifier>{0D1AF264-3AC1-78A2-B2A4-AE6171F9194A}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="JUCE Modules\juce_audio_devices">
+      <UniqueIdentifier>{9A5DB854-CFFB-5F88-C566-0E10F994DDB3}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="JUCE Modules\juce_audio_formats\codecs\flac\libFLAC\deduplication">
+      <UniqueIdentifier>{2D16C77A-4E5B-B439-2856-90E03028DA07}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="JUCE Modules\juce_audio_formats\codecs\flac\libFLAC\include\private">
+      <UniqueIdentifier>{38A5DDC7-416E-548F-39DA-887875FE6B20}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="JUCE Modules\juce_audio_formats\codecs\flac\libFLAC\include\protected">
+      <UniqueIdentifier>{980FE2DB-05D3-5FDA-79DA-067A56F5D19D}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="JUCE Modules\juce_audio_formats\codecs\flac\libFLAC\include">
+      <UniqueIdentifier>{F336DC25-747A-0663-93D6-E3EB9AA0CBF8}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="JUCE Modules\juce_audio_formats\codecs\flac\libFLAC">
+      <UniqueIdentifier>{7D78546A-80FC-4DCA-00B9-F191F0AB2179}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="JUCE Modules\juce_audio_formats\codecs\flac">
+      <UniqueIdentifier>{9EB3EC7F-2AB7-DDAA-3C05-DF382B728D3F}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="JUCE Modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\books\coupled">
+      <UniqueIdentifier>{6B9FBFDC-1D10-6246-356D-00FF4535CECB}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="JUCE Modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\books\floor">
+      <UniqueIdentifier>{D6FCFC8E-7136-9109-78C0-91A3EB4C443F}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="JUCE Modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\books\uncoupled">
+      <UniqueIdentifier>{EBF18AC1-F0ED-937A-2824-4307CE2ADAF7}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="JUCE Modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\books">
+      <UniqueIdentifier>{5A0F7922-2EFB-6465-57E4-A445B804EFB5}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="JUCE Modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\modes">
+      <UniqueIdentifier>{4EC45416-0E7C-7567-6F75-D0C8CEE7DC4F}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="JUCE Modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib">
+      <UniqueIdentifier>{C2985031-0496-55B5-41A8-BAB99E53D89D}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="JUCE Modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7">
+      <UniqueIdentifier>{FB4AB426-7009-0036-BB75-E34256AA7C89}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="JUCE Modules\juce_audio_formats\codecs\oggvorbis">
+      <UniqueIdentifier>{E684D858-09E8-0251-8E86-5657129641E1}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="JUCE Modules\juce_audio_formats\codecs">
+      <UniqueIdentifier>{1EF1BF17-F941-243A-04D1-EE617D140CBA}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="JUCE Modules\juce_audio_formats\format">
+      <UniqueIdentifier>{344DB016-679C-FBD0-3EC6-4570C47522DE}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="JUCE Modules\juce_audio_formats\sampler">
+      <UniqueIdentifier>{3D9758A0-9359-1710-87C1-05D475C08B17}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="JUCE Modules\juce_audio_formats">
+      <UniqueIdentifier>{E824435F-FC7B-10BE-5D1A-5DACC51A8836}</UniqueIdentifier>
+    </Filter>
     <Filter Include="JUCE Modules\juce_audio_plugin_client\detail">
       <UniqueIdentifier>{50461EB0-68B5-5582-2DE2-81B0FE171231}</UniqueIdentifier>
     </Filter>
@@ -376,6 +481,21 @@
     </Filter>
     <Filter Include="JUCE Modules\juce_audio_processors_headless">
       <UniqueIdentifier>{948A112F-4A55-FA00-E3DB-35DF596E09C2}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="JUCE Modules\juce_audio_utils\audio_cd">
+      <UniqueIdentifier>{1A9C8538-959B-25E3-473D-B462C9A9D458}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="JUCE Modules\juce_audio_utils\gui">
+      <UniqueIdentifier>{AA9F594C-DFAF-C0A7-0CCD-9F90E54D3A01}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="JUCE Modules\juce_audio_utils\native">
+      <UniqueIdentifier>{230BF784-34F4-3BE8-46D4-54E6B67E5E9E}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="JUCE Modules\juce_audio_utils\players">
+      <UniqueIdentifier>{39F680F3-5161-4D1C-EAD0-3911ED808874}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="JUCE Modules\juce_audio_utils">
+      <UniqueIdentifier>{3197198B-A978-E330-C7FB-07E5CE8236C7}</UniqueIdentifier>
     </Filter>
     <Filter Include="JUCE Modules\juce_core\containers">
       <UniqueIdentifier>{42F7BE9D-3C8A-AE26-289B-8F355C068036}</UniqueIdentifier>
@@ -1153,6 +1273,489 @@
     <ClCompile Include="..\..\External\juce\modules\juce_audio_basics\juce_audio_basics.mm">
       <Filter>JUCE Modules\juce_audio_basics</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\audio_io\juce_AudioDeviceManager.cpp">
+      <Filter>JUCE Modules\juce_audio_devices\audio_io</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\audio_io\juce_AudioIODevice.cpp">
+      <Filter>JUCE Modules\juce_audio_devices\audio_io</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\audio_io\juce_AudioIODeviceType.cpp">
+      <Filter>JUCE Modules\juce_audio_devices\audio_io</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\audio_io\juce_SampleRateHelpers.cpp">
+      <Filter>JUCE Modules\juce_audio_devices\audio_io</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\midi_io\ump\juce_UMPBlock.cpp">
+      <Filter>JUCE Modules\juce_audio_devices\midi_io\ump</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\midi_io\ump\juce_UMPEndpointId.cpp">
+      <Filter>JUCE Modules\juce_audio_devices\midi_io\ump</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\midi_io\ump\juce_UMPEndpoints.cpp">
+      <Filter>JUCE Modules\juce_audio_devices\midi_io\ump</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\midi_io\ump\juce_UMPInput.cpp">
+      <Filter>JUCE Modules\juce_audio_devices\midi_io\ump</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\midi_io\ump\juce_UMPIOHelpers.cpp">
+      <Filter>JUCE Modules\juce_audio_devices\midi_io\ump</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\midi_io\ump\juce_UMPLegacyVirtualInput.cpp">
+      <Filter>JUCE Modules\juce_audio_devices\midi_io\ump</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\midi_io\ump\juce_UMPLegacyVirtualOutput.cpp">
+      <Filter>JUCE Modules\juce_audio_devices\midi_io\ump</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\midi_io\ump\juce_UMPOutput.cpp">
+      <Filter>JUCE Modules\juce_audio_devices\midi_io\ump</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\midi_io\ump\juce_UMPSession.cpp">
+      <Filter>JUCE Modules\juce_audio_devices\midi_io\ump</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\midi_io\ump\juce_UMPVirtualEndpoint.cpp">
+      <Filter>JUCE Modules\juce_audio_devices\midi_io\ump</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\midi_io\juce_MidiDeviceListConnectionBroadcaster.cpp">
+      <Filter>JUCE Modules\juce_audio_devices\midi_io</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\midi_io\juce_MidiDevices.cpp">
+      <Filter>JUCE Modules\juce_audio_devices\midi_io</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\midi_io\juce_MidiMessageCollector.cpp">
+      <Filter>JUCE Modules\juce_audio_devices\midi_io</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\midi_io\juce_WaitFreeListeners.cpp">
+      <Filter>JUCE Modules\juce_audio_devices\midi_io</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\aaudio\AAudioLoader.cpp">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\aaudio</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\aaudio\AudioStreamAAudio.cpp">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\aaudio</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\common\AdpfWrapper.cpp">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\common\AudioSourceCaller.cpp">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\common\AudioStream.cpp">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\common\AudioStreamBuilder.cpp">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\common\DataConversionFlowGraph.cpp">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\common\FilterAudioStream.cpp">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\common\FixedBlockAdapter.cpp">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\common\FixedBlockReader.cpp">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\common\FixedBlockWriter.cpp">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\common\LatencyTuner.cpp">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\common\OboeExtensions.cpp">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\common\QuirksManager.cpp">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\common\SourceFloatCaller.cpp">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\common\SourceI16Caller.cpp">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\common\SourceI24Caller.cpp">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\common\SourceI32Caller.cpp">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\common\StabilizedCallback.cpp">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\common\Trace.cpp">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\common\Utilities.cpp">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\common\Version.cpp">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\fifo\FifoBuffer.cpp">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\fifo</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\fifo\FifoController.cpp">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\fifo</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\fifo\FifoControllerBase.cpp">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\fifo</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\fifo\FifoControllerIndirect.cpp">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\fifo</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\resampler\IntegerRatio.cpp">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\flowgraph\resampler</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\resampler\LinearResampler.cpp">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\flowgraph\resampler</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\resampler\MultiChannelResampler.cpp">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\flowgraph\resampler</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\resampler\PolyphaseResampler.cpp">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\flowgraph\resampler</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\resampler\PolyphaseResamplerMono.cpp">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\flowgraph\resampler</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\resampler\PolyphaseResamplerStereo.cpp">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\flowgraph\resampler</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\resampler\SincResampler.cpp">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\flowgraph\resampler</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\resampler\SincResamplerStereo.cpp">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\flowgraph\resampler</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\ChannelCountConverter.cpp">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\flowgraph</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\ClipToRange.cpp">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\flowgraph</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\FlowGraphNode.cpp">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\flowgraph</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\Limiter.cpp">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\flowgraph</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\ManyToMultiConverter.cpp">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\flowgraph</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\MonoBlend.cpp">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\flowgraph</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\MonoToMultiConverter.cpp">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\flowgraph</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\MultiToManyConverter.cpp">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\flowgraph</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\MultiToMonoConverter.cpp">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\flowgraph</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\RampLinear.cpp">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\flowgraph</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\SampleRateConverter.cpp">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\flowgraph</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\SinkFloat.cpp">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\flowgraph</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\SinkI8_24.cpp">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\flowgraph</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\SinkI16.cpp">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\flowgraph</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\SinkI24.cpp">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\flowgraph</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\SinkI32.cpp">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\flowgraph</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\SourceFloat.cpp">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\flowgraph</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\SourceI8_24.cpp">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\flowgraph</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\SourceI16.cpp">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\flowgraph</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\SourceI24.cpp">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\flowgraph</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\SourceI32.cpp">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\flowgraph</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\opensles\AudioInputStreamOpenSLES.cpp">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\opensles</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\opensles\AudioOutputStreamOpenSLES.cpp">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\opensles</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\opensles\AudioStreamBuffered.cpp">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\opensles</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\opensles\AudioStreamOpenSLES.cpp">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\opensles</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\opensles\EngineOpenSLES.cpp">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\opensles</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\opensles\OpenSLESUtilities.cpp">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\opensles</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\opensles\OutputMixerOpenSLES.cpp">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\opensles</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\juce_ALSA_linux.cpp">
+      <Filter>JUCE Modules\juce_audio_devices\native</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\juce_ASIO_windows.cpp">
+      <Filter>JUCE Modules\juce_audio_devices\native</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\juce_Audio_android.cpp">
+      <Filter>JUCE Modules\juce_audio_devices\native</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\juce_Audio_ios.cpp">
+      <Filter>JUCE Modules\juce_audio_devices\native</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\juce_CoreAudio_mac.cpp">
+      <Filter>JUCE Modules\juce_audio_devices\native</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\juce_CoreMidi_mac.mm">
+      <Filter>JUCE Modules\juce_audio_devices\native</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\juce_DirectSound_windows.cpp">
+      <Filter>JUCE Modules\juce_audio_devices\native</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\juce_JackAudio.cpp">
+      <Filter>JUCE Modules\juce_audio_devices\native</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\juce_Midi_android.cpp">
+      <Filter>JUCE Modules\juce_audio_devices\native</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\juce_Midi_linux.cpp">
+      <Filter>JUCE Modules\juce_audio_devices\native</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\juce_Midi_windows.cpp">
+      <Filter>JUCE Modules\juce_audio_devices\native</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\juce_Oboe_android.cpp">
+      <Filter>JUCE Modules\juce_audio_devices\native</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\juce_OpenSL_android.cpp">
+      <Filter>JUCE Modules\juce_audio_devices\native</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\native\juce_WASAPI_windows.cpp">
+      <Filter>JUCE Modules\juce_audio_devices\native</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\sources\juce_AudioSourcePlayer.cpp">
+      <Filter>JUCE Modules\juce_audio_devices\sources</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\sources\juce_AudioTransportSource.cpp">
+      <Filter>JUCE Modules\juce_audio_devices\sources</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\juce_audio_devices.cpp">
+      <Filter>JUCE Modules\juce_audio_devices</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_devices\juce_audio_devices.mm">
+      <Filter>JUCE Modules\juce_audio_devices</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\codecs\flac\libFLAC\deduplication\bitreader_read_rice_signed_block.c">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\flac\libFLAC\deduplication</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\codecs\flac\libFLAC\deduplication\lpc_compute_autocorrelation_intrin.c">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\flac\libFLAC\deduplication</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\codecs\flac\libFLAC\deduplication\lpc_compute_autocorrelation_intrin_neon.c">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\flac\libFLAC\deduplication</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\codecs\flac\libFLAC\bitmath.c">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\flac\libFLAC</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\codecs\flac\libFLAC\bitreader.c">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\flac\libFLAC</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\codecs\flac\libFLAC\bitwriter.c">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\flac\libFLAC</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\codecs\flac\libFLAC\cpu.c">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\flac\libFLAC</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\codecs\flac\libFLAC\crc.c">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\flac\libFLAC</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\codecs\flac\libFLAC\fixed.c">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\flac\libFLAC</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\codecs\flac\libFLAC\float.c">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\flac\libFLAC</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\codecs\flac\libFLAC\format.c">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\flac\libFLAC</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\codecs\flac\libFLAC\lpc_flac.c">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\flac\libFLAC</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\codecs\flac\libFLAC\lpc_intrin_neon.c">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\flac\libFLAC</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\codecs\flac\libFLAC\md5.c">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\flac\libFLAC</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\codecs\flac\libFLAC\memory.c">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\flac\libFLAC</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\codecs\flac\libFLAC\stream_decoder.c">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\flac\libFLAC</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\codecs\flac\libFLAC\stream_encoder.c">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\flac\libFLAC</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\codecs\flac\libFLAC\stream_encoder_framing.c">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\flac\libFLAC</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\codecs\flac\libFLAC\window_flac.c">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\flac\libFLAC</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\analysis.c">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\bitrate.c">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\block.c">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\codebook.c">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\envelope.c">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\floor0.c">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\floor1.c">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\info.c">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\lookup.c">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\lpc.c">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\lsp.c">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\mapping0.c">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\mdct.c">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\misc.c">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\psy.c">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\registry.c">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\res0.c">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\sharedbook.c">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\smallft.c">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\synthesis.c">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\vorbisenc.c">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\vorbisfile.c">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\window.c">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\bitwise.c">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\oggvorbis</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\framing.c">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\oggvorbis</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\codecs\juce_AiffAudioFormat.cpp">
+      <Filter>JUCE Modules\juce_audio_formats\codecs</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\codecs\juce_CoreAudioFormat.cpp">
+      <Filter>JUCE Modules\juce_audio_formats\codecs</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\codecs\juce_FlacAudioFormat.cpp">
+      <Filter>JUCE Modules\juce_audio_formats\codecs</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\codecs\juce_LAMEEncoderAudioFormat.cpp">
+      <Filter>JUCE Modules\juce_audio_formats\codecs</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\codecs\juce_MP3AudioFormat.cpp">
+      <Filter>JUCE Modules\juce_audio_formats\codecs</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\codecs\juce_OggVorbisAudioFormat.cpp">
+      <Filter>JUCE Modules\juce_audio_formats\codecs</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\codecs\juce_WavAudioFormat.cpp">
+      <Filter>JUCE Modules\juce_audio_formats\codecs</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\codecs\juce_WindowsMediaAudioFormat.cpp">
+      <Filter>JUCE Modules\juce_audio_formats\codecs</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\format\juce_ARAAudioReaders.cpp">
+      <Filter>JUCE Modules\juce_audio_formats\format</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\format\juce_AudioFormat.cpp">
+      <Filter>JUCE Modules\juce_audio_formats\format</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\format\juce_AudioFormatManager.cpp">
+      <Filter>JUCE Modules\juce_audio_formats\format</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\format\juce_AudioFormatReader.cpp">
+      <Filter>JUCE Modules\juce_audio_formats\format</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\format\juce_AudioFormatReaderSource.cpp">
+      <Filter>JUCE Modules\juce_audio_formats\format</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\format\juce_AudioFormatWriter.cpp">
+      <Filter>JUCE Modules\juce_audio_formats\format</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\format\juce_AudioSubsectionReader.cpp">
+      <Filter>JUCE Modules\juce_audio_formats\format</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\format\juce_BufferingAudioFormatReader.cpp">
+      <Filter>JUCE Modules\juce_audio_formats\format</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\sampler\juce_Sampler.cpp">
+      <Filter>JUCE Modules\juce_audio_formats\sampler</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\juce_audio_formats.cpp">
+      <Filter>JUCE Modules\juce_audio_formats</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_formats\juce_audio_formats.mm">
+      <Filter>JUCE Modules\juce_audio_formats</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\External\juce\modules\juce_audio_plugin_client\juce_audio_plugin_client_ARA.cpp">
       <Filter>JUCE Modules\juce_audio_plugin_client</Filter>
     </ClCompile>
@@ -1527,6 +2130,75 @@
     </ClCompile>
     <ClCompile Include="..\..\External\juce\modules\juce_audio_processors_headless\juce_audio_processors_headless_lv2_libs.cpp">
       <Filter>JUCE Modules\juce_audio_processors_headless</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_utils\audio_cd\juce_AudioCDReader.cpp">
+      <Filter>JUCE Modules\juce_audio_utils\audio_cd</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_utils\gui\juce_AudioAppComponent.cpp">
+      <Filter>JUCE Modules\juce_audio_utils\gui</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_utils\gui\juce_AudioDeviceSelectorComponent.cpp">
+      <Filter>JUCE Modules\juce_audio_utils\gui</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_utils\gui\juce_AudioThumbnail.cpp">
+      <Filter>JUCE Modules\juce_audio_utils\gui</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_utils\gui\juce_AudioThumbnailCache.cpp">
+      <Filter>JUCE Modules\juce_audio_utils\gui</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_utils\gui\juce_AudioVisualiserComponent.cpp">
+      <Filter>JUCE Modules\juce_audio_utils\gui</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_utils\gui\juce_KeyboardComponentBase.cpp">
+      <Filter>JUCE Modules\juce_audio_utils\gui</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_utils\gui\juce_MidiKeyboardComponent.cpp">
+      <Filter>JUCE Modules\juce_audio_utils\gui</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_utils\gui\juce_MPEKeyboardComponent.cpp">
+      <Filter>JUCE Modules\juce_audio_utils\gui</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_utils\native\juce_AudioCDBurner_mac.mm">
+      <Filter>JUCE Modules\juce_audio_utils\native</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_utils\native\juce_AudioCDBurner_windows.cpp">
+      <Filter>JUCE Modules\juce_audio_utils\native</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_utils\native\juce_AudioCDReader_linux.cpp">
+      <Filter>JUCE Modules\juce_audio_utils\native</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_utils\native\juce_AudioCDReader_mac.mm">
+      <Filter>JUCE Modules\juce_audio_utils\native</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_utils\native\juce_AudioCDReader_windows.cpp">
+      <Filter>JUCE Modules\juce_audio_utils\native</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_utils\native\juce_BluetoothMidiDevicePairingDialogue_android.cpp">
+      <Filter>JUCE Modules\juce_audio_utils\native</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_utils\native\juce_BluetoothMidiDevicePairingDialogue_ios.mm">
+      <Filter>JUCE Modules\juce_audio_utils\native</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_utils\native\juce_BluetoothMidiDevicePairingDialogue_linux.cpp">
+      <Filter>JUCE Modules\juce_audio_utils\native</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_utils\native\juce_BluetoothMidiDevicePairingDialogue_mac.mm">
+      <Filter>JUCE Modules\juce_audio_utils\native</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_utils\native\juce_BluetoothMidiDevicePairingDialogue_windows.cpp">
+      <Filter>JUCE Modules\juce_audio_utils\native</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_utils\players\juce_AudioProcessorPlayer.cpp">
+      <Filter>JUCE Modules\juce_audio_utils\players</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_utils\players\juce_SoundPlayer.cpp">
+      <Filter>JUCE Modules\juce_audio_utils\players</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_utils\juce_audio_utils.cpp">
+      <Filter>JUCE Modules\juce_audio_utils</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_utils\juce_audio_utils.mm">
+      <Filter>JUCE Modules\juce_audio_utils</Filter>
     </ClCompile>
     <ClCompile Include="..\..\External\juce\modules\juce_core\containers\juce_AbstractFifo.cpp">
       <Filter>JUCE Modules\juce_core\containers</Filter>
@@ -3385,6 +4057,12 @@
     <ClCompile Include="..\..\JuceLibraryCode\include_juce_audio_basics.cpp">
       <Filter>JUCE Library Code</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\JuceLibraryCode\include_juce_audio_devices.cpp">
+      <Filter>JUCE Library Code</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\JuceLibraryCode\include_juce_audio_formats.cpp">
+      <Filter>JUCE Library Code</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\JuceLibraryCode\include_juce_audio_plugin_client_ARA.cpp">
       <Filter>JUCE Library Code</Filter>
     </ClCompile>
@@ -3398,6 +4076,9 @@
       <Filter>JUCE Library Code</Filter>
     </ClCompile>
     <ClCompile Include="..\..\JuceLibraryCode\include_juce_audio_processors_headless_lv2_libs.cpp">
+      <Filter>JUCE Library Code</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\JuceLibraryCode\include_juce_audio_utils.cpp">
       <Filter>JUCE Library Code</Filter>
     </ClCompile>
     <ClCompile Include="..\..\JuceLibraryCode\include_juce_core.cpp">
@@ -4263,6 +4944,615 @@
     <ClInclude Include="..\..\External\juce\modules\juce_audio_basics\juce_audio_basics.h">
       <Filter>JUCE Modules\juce_audio_basics</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\audio_io\juce_AudioDeviceManager.h">
+      <Filter>JUCE Modules\juce_audio_devices\audio_io</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\audio_io\juce_AudioIODevice.h">
+      <Filter>JUCE Modules\juce_audio_devices\audio_io</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\audio_io\juce_AudioIODeviceType.h">
+      <Filter>JUCE Modules\juce_audio_devices\audio_io</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\audio_io\juce_SystemAudioVolume.h">
+      <Filter>JUCE Modules\juce_audio_devices\audio_io</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\midi_io\ump\juce_UMPBlock.h">
+      <Filter>JUCE Modules\juce_audio_devices\midi_io\ump</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\midi_io\ump\juce_UMPDisconnectionListener.h">
+      <Filter>JUCE Modules\juce_audio_devices\midi_io\ump</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\midi_io\ump\juce_UMPEndpoint.h">
+      <Filter>JUCE Modules\juce_audio_devices\midi_io\ump</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\midi_io\ump\juce_UMPEndpointId.h">
+      <Filter>JUCE Modules\juce_audio_devices\midi_io\ump</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\midi_io\ump\juce_UMPEndpoints.h">
+      <Filter>JUCE Modules\juce_audio_devices\midi_io\ump</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\midi_io\ump\juce_UMPInput.h">
+      <Filter>JUCE Modules\juce_audio_devices\midi_io\ump</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\midi_io\ump\juce_UMPLegacyVirtualInput.h">
+      <Filter>JUCE Modules\juce_audio_devices\midi_io\ump</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\midi_io\ump\juce_UMPLegacyVirtualOutput.h">
+      <Filter>JUCE Modules\juce_audio_devices\midi_io\ump</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\midi_io\ump\juce_UMPOutput.h">
+      <Filter>JUCE Modules\juce_audio_devices\midi_io\ump</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\midi_io\ump\juce_UMPSession.h">
+      <Filter>JUCE Modules\juce_audio_devices\midi_io\ump</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\midi_io\ump\juce_UMPStaticDeviceInfo.h">
+      <Filter>JUCE Modules\juce_audio_devices\midi_io\ump</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\midi_io\ump\juce_UMPVirtualEndpoint.h">
+      <Filter>JUCE Modules\juce_audio_devices\midi_io\ump</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\midi_io\juce_MidiDevices.h">
+      <Filter>JUCE Modules\juce_audio_devices\midi_io</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\midi_io\juce_MidiMessageCollector.h">
+      <Filter>JUCE Modules\juce_audio_devices\midi_io</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\midi_io\juce_ScheduledEventThread.h">
+      <Filter>JUCE Modules\juce_audio_devices\midi_io</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\midi_io\juce_WaitFreeListeners.h">
+      <Filter>JUCE Modules\juce_audio_devices\midi_io</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\asio\asio.h">
+      <Filter>JUCE Modules\juce_audio_devices\native\asio</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\asio\asiosys.h">
+      <Filter>JUCE Modules\juce_audio_devices\native\asio</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\asio\iasiodrv.h">
+      <Filter>JUCE Modules\juce_audio_devices\native\asio</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\include\oboe\AudioStream.h">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\include\oboe</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\include\oboe\AudioStreamBase.h">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\include\oboe</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\include\oboe\AudioStreamBuilder.h">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\include\oboe</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\include\oboe\AudioStreamCallback.h">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\include\oboe</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\include\oboe\Definitions.h">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\include\oboe</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\include\oboe\FifoBuffer.h">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\include\oboe</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\include\oboe\FifoControllerBase.h">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\include\oboe</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\include\oboe\FullDuplexStream.h">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\include\oboe</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\include\oboe\LatencyTuner.h">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\include\oboe</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\include\oboe\Oboe.h">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\include\oboe</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\include\oboe\OboeExtensions.h">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\include\oboe</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\include\oboe\ResultWithValue.h">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\include\oboe</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\include\oboe\StabilizedCallback.h">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\include\oboe</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\include\oboe\Utilities.h">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\include\oboe</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\include\oboe\Version.h">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\include\oboe</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\aaudio\AAudioExtensions.h">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\aaudio</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\aaudio\AAudioLoader.h">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\aaudio</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\aaudio\AudioStreamAAudio.h">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\aaudio</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\common\AdpfWrapper.h">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\common\AudioClock.h">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\common\AudioSourceCaller.h">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\common\DataConversionFlowGraph.h">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\common\FilterAudioStream.h">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\common\FixedBlockAdapter.h">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\common\FixedBlockReader.h">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\common\FixedBlockWriter.h">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\common\MonotonicCounter.h">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\common\OboeDebug.h">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\common\QuirksManager.h">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\common\SourceFloatCaller.h">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\common\SourceI16Caller.h">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\common\SourceI24Caller.h">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\common\SourceI32Caller.h">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\common\Trace.h">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\fifo\FifoController.h">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\fifo</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\fifo\FifoControllerIndirect.h">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\fifo</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\resampler\HyperbolicCosineWindow.h">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\flowgraph\resampler</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\resampler\IntegerRatio.h">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\flowgraph\resampler</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\resampler\KaiserWindow.h">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\flowgraph\resampler</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\resampler\LinearResampler.h">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\flowgraph\resampler</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\resampler\MultiChannelResampler.h">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\flowgraph\resampler</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\resampler\PolyphaseResampler.h">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\flowgraph\resampler</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\resampler\PolyphaseResamplerMono.h">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\flowgraph\resampler</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\resampler\PolyphaseResamplerStereo.h">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\flowgraph\resampler</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\resampler\ResamplerDefinitions.h">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\flowgraph\resampler</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\resampler\SincResampler.h">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\flowgraph\resampler</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\resampler\SincResamplerStereo.h">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\flowgraph\resampler</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\ChannelCountConverter.h">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\flowgraph</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\ClipToRange.h">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\flowgraph</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\FlowGraphNode.h">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\flowgraph</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\FlowgraphUtilities.h">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\flowgraph</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\Limiter.h">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\flowgraph</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\ManyToMultiConverter.h">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\flowgraph</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\MonoBlend.h">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\flowgraph</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\MonoToMultiConverter.h">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\flowgraph</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\MultiToManyConverter.h">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\flowgraph</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\MultiToMonoConverter.h">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\flowgraph</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\RampLinear.h">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\flowgraph</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\SampleRateConverter.h">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\flowgraph</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\SinkFloat.h">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\flowgraph</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\SinkI8_24.h">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\flowgraph</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\SinkI16.h">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\flowgraph</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\SinkI24.h">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\flowgraph</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\SinkI32.h">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\flowgraph</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\SourceFloat.h">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\flowgraph</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\SourceI8_24.h">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\flowgraph</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\SourceI16.h">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\flowgraph</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\SourceI24.h">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\flowgraph</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\SourceI32.h">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\flowgraph</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\opensles\AudioInputStreamOpenSLES.h">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\opensles</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\opensles\AudioOutputStreamOpenSLES.h">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\opensles</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\opensles\AudioStreamBuffered.h">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\opensles</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\opensles\AudioStreamOpenSLES.h">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\opensles</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\opensles\EngineOpenSLES.h">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\opensles</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\opensles\OpenSLESUtilities.h">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\opensles</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\opensles\OutputMixerOpenSLES.h">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\opensles</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\juce_ALSA_weak_linux.h">
+      <Filter>JUCE Modules\juce_audio_devices\native</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\juce_Audio_ios.h">
+      <Filter>JUCE Modules\juce_audio_devices\native</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\native\juce_HighPerformanceAudioHelpers_android.h">
+      <Filter>JUCE Modules\juce_audio_devices\native</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\sources\juce_AudioSourcePlayer.h">
+      <Filter>JUCE Modules\juce_audio_devices\sources</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\sources\juce_AudioTransportSource.h">
+      <Filter>JUCE Modules\juce_audio_devices\sources</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_devices\juce_audio_devices.h">
+      <Filter>JUCE Modules\juce_audio_devices</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\flac\libFLAC\include\private\bitmath.h">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\flac\libFLAC\include\private</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\flac\libFLAC\include\private\bitreader.h">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\flac\libFLAC\include\private</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\flac\libFLAC\include\private\bitwriter.h">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\flac\libFLAC\include\private</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\flac\libFLAC\include\private\cpu.h">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\flac\libFLAC\include\private</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\flac\libFLAC\include\private\crc.h">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\flac\libFLAC\include\private</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\flac\libFLAC\include\private\fixed.h">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\flac\libFLAC\include\private</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\flac\libFLAC\include\private\float.h">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\flac\libFLAC\include\private</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\flac\libFLAC\include\private\format.h">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\flac\libFLAC\include\private</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\flac\libFLAC\include\private\lpc.h">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\flac\libFLAC\include\private</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\flac\libFLAC\include\private\md5.h">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\flac\libFLAC\include\private</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\flac\libFLAC\include\private\memory.h">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\flac\libFLAC\include\private</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\flac\libFLAC\include\private\stream_encoder.h">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\flac\libFLAC\include\private</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\flac\libFLAC\include\private\stream_encoder_framing.h">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\flac\libFLAC\include\private</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\flac\libFLAC\include\private\window.h">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\flac\libFLAC\include\private</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\flac\libFLAC\include\protected\stream_decoder.h">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\flac\libFLAC\include\protected</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\flac\libFLAC\include\protected\stream_encoder.h">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\flac\libFLAC\include\protected</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\flac\all.h">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\flac</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\flac\alloc.h">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\flac</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\flac\assert.h">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\flac</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\flac\callback.h">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\flac</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\flac\compat.h">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\flac</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\flac\endswap.h">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\flac</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\flac\export.h">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\flac</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\flac\format.h">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\flac</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\flac\metadata.h">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\flac</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\flac\ordinals.h">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\flac</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\flac\private.h">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\flac</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\flac\stream_decoder.h">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\flac</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\flac\stream_encoder.h">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\flac</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\books\coupled\res_books_51.h">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\books\coupled</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\books\coupled\res_books_stereo.h">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\books\coupled</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\books\floor\floor_books.h">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\books\floor</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\books\uncoupled\res_books_uncoupled.h">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\books\uncoupled</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\modes\floor_all.h">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\modes</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\modes\psych_8.h">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\modes</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\modes\psych_11.h">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\modes</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\modes\psych_16.h">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\modes</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\modes\psych_44.h">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\modes</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\modes\residue_8.h">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\modes</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\modes\residue_16.h">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\modes</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\modes\residue_44.h">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\modes</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\modes\residue_44p51.h">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\modes</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\modes\residue_44u.h">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\modes</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\modes\setup_8.h">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\modes</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\modes\setup_11.h">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\modes</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\modes\setup_16.h">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\modes</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\modes\setup_22.h">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\modes</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\modes\setup_32.h">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\modes</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\modes\setup_44.h">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\modes</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\modes\setup_44p51.h">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\modes</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\modes\setup_44u.h">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\modes</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\modes\setup_X.h">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\modes</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\backends.h">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\bitrate.h">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\codebook.h">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\codec_internal.h">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\envelope.h">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\highlevel.h">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\lookup.h">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\lookup_data.h">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\lpc.h">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\lsp.h">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\masking.h">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\mdct.h">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\misc.h">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\os.h">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\psy.h">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\registry.h">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\scales.h">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\smallft.h">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib\window.h">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\lib</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\codec.h">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\oggvorbis</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\config_types.h">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\oggvorbis</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\crctable.h">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\oggvorbis</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\ogg.h">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\oggvorbis</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\os_types.h">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\oggvorbis</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\vorbisenc.h">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\oggvorbis</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\vorbisfile.h">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\oggvorbis</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\juce_AiffAudioFormat.h">
+      <Filter>JUCE Modules\juce_audio_formats\codecs</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\juce_CoreAudioFormat.h">
+      <Filter>JUCE Modules\juce_audio_formats\codecs</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\juce_FlacAudioFormat.h">
+      <Filter>JUCE Modules\juce_audio_formats\codecs</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\juce_LAMEEncoderAudioFormat.h">
+      <Filter>JUCE Modules\juce_audio_formats\codecs</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\juce_MP3AudioFormat.h">
+      <Filter>JUCE Modules\juce_audio_formats\codecs</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\juce_OggVorbisAudioFormat.h">
+      <Filter>JUCE Modules\juce_audio_formats\codecs</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\juce_WavAudioFormat.h">
+      <Filter>JUCE Modules\juce_audio_formats\codecs</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\codecs\juce_WindowsMediaAudioFormat.h">
+      <Filter>JUCE Modules\juce_audio_formats\codecs</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\format\juce_ARAAudioReaders.h">
+      <Filter>JUCE Modules\juce_audio_formats\format</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\format\juce_AudioFormat.h">
+      <Filter>JUCE Modules\juce_audio_formats\format</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\format\juce_AudioFormatManager.h">
+      <Filter>JUCE Modules\juce_audio_formats\format</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\format\juce_AudioFormatReader.h">
+      <Filter>JUCE Modules\juce_audio_formats\format</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\format\juce_AudioFormatReaderSource.h">
+      <Filter>JUCE Modules\juce_audio_formats\format</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\format\juce_AudioFormatWriter.h">
+      <Filter>JUCE Modules\juce_audio_formats\format</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\format\juce_AudioFormatWriterOptions.h">
+      <Filter>JUCE Modules\juce_audio_formats\format</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\format\juce_AudioSubsectionReader.h">
+      <Filter>JUCE Modules\juce_audio_formats\format</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\format\juce_BufferingAudioFormatReader.h">
+      <Filter>JUCE Modules\juce_audio_formats\format</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\format\juce_MemoryMappedAudioFormatReader.h">
+      <Filter>JUCE Modules\juce_audio_formats\format</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\sampler\juce_Sampler.h">
+      <Filter>JUCE Modules\juce_audio_formats\sampler</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_formats\juce_audio_formats.h">
+      <Filter>JUCE Modules\juce_audio_formats</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\External\juce\modules\juce_audio_plugin_client\detail\juce_CheckSettingMacros.h">
       <Filter>JUCE Modules\juce_audio_plugin_client\detail</Filter>
     </ClInclude>
@@ -4958,6 +6248,51 @@
     </ClInclude>
     <ClInclude Include="..\..\External\juce\modules\juce_audio_processors_headless\juce_audio_processors_headless.h">
       <Filter>JUCE Modules\juce_audio_processors_headless</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_utils\audio_cd\juce_AudioCDBurner.h">
+      <Filter>JUCE Modules\juce_audio_utils\audio_cd</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_utils\audio_cd\juce_AudioCDReader.h">
+      <Filter>JUCE Modules\juce_audio_utils\audio_cd</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_utils\gui\juce_AudioAppComponent.h">
+      <Filter>JUCE Modules\juce_audio_utils\gui</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_utils\gui\juce_AudioDeviceSelectorComponent.h">
+      <Filter>JUCE Modules\juce_audio_utils\gui</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_utils\gui\juce_AudioThumbnail.h">
+      <Filter>JUCE Modules\juce_audio_utils\gui</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_utils\gui\juce_AudioThumbnailBase.h">
+      <Filter>JUCE Modules\juce_audio_utils\gui</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_utils\gui\juce_AudioThumbnailCache.h">
+      <Filter>JUCE Modules\juce_audio_utils\gui</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_utils\gui\juce_AudioVisualiserComponent.h">
+      <Filter>JUCE Modules\juce_audio_utils\gui</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_utils\gui\juce_BluetoothMidiDevicePairingDialogue.h">
+      <Filter>JUCE Modules\juce_audio_utils\gui</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_utils\gui\juce_KeyboardComponentBase.h">
+      <Filter>JUCE Modules\juce_audio_utils\gui</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_utils\gui\juce_MidiKeyboardComponent.h">
+      <Filter>JUCE Modules\juce_audio_utils\gui</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_utils\gui\juce_MPEKeyboardComponent.h">
+      <Filter>JUCE Modules\juce_audio_utils\gui</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_utils\players\juce_AudioProcessorPlayer.h">
+      <Filter>JUCE Modules\juce_audio_utils\players</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_utils\players\juce_SoundPlayer.h">
+      <Filter>JUCE Modules\juce_audio_utils\players</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_utils\juce_audio_utils.h">
+      <Filter>JUCE Modules\juce_audio_utils</Filter>
     </ClInclude>
     <ClInclude Include="..\..\External\juce\modules\juce_core\containers\juce_AbstractFifo.h">
       <Filter>JUCE Modules\juce_core\containers</Filter>
@@ -7544,6 +8879,9 @@
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
+    <None Include="..\..\build.py">
+      <Filter>Signalizer\Build</Filter>
+    </None>
     <None Include="..\..\Make\build_linux.py">
       <Filter>Signalizer\Build</Filter>
     </None>
@@ -7560,6 +8898,9 @@
       <Filter>Signalizer\Build</Filter>
     </None>
     <None Include="..\..\Make\macos_installation_advice.txt">
+      <Filter>Signalizer\Build</Filter>
+    </None>
+    <None Include="..\..\prepare.py">
       <Filter>Signalizer\Build</Filter>
     </None>
     <None Include="..\..\Make\vscompile.bat">
@@ -7627,6 +8968,33 @@
     </None>
     <None Include="..\..\Source\Notes\Bugs.txt">
       <Filter>Signalizer\Notes</Filter>
+    </None>
+    <None Include="..\..\External\juce\modules\juce_audio_devices\native\asio\LICENSE.txt">
+      <Filter>JUCE Modules\juce_audio_devices\native\asio</Filter>
+    </None>
+    <None Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\common\README.md">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\common</Filter>
+    </None>
+    <None Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\src\flowgraph\resampler\README.md">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe\src\flowgraph\resampler</Filter>
+    </None>
+    <None Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\CMakeLists.txt">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe</Filter>
+    </None>
+    <None Include="..\..\External\juce\modules\juce_audio_devices\native\oboe\README.md">
+      <Filter>JUCE Modules\juce_audio_devices\native\oboe</Filter>
+    </None>
+    <None Include="..\..\External\juce\modules\juce_audio_formats\codecs\flac\Flac Licence.txt">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\flac</Filter>
+    </None>
+    <None Include="..\..\External\juce\modules\juce_audio_formats\codecs\flac\JUCE_CHANGES.txt">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\flac</Filter>
+    </None>
+    <None Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7\README.md">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\oggvorbis\libvorbis-1.3.7</Filter>
+    </None>
+    <None Include="..\..\External\juce\modules\juce_audio_formats\codecs\oggvorbis\Ogg Vorbis Licence.txt">
+      <Filter>JUCE Modules\juce_audio_formats\codecs\oggvorbis</Filter>
     </None>
     <None Include="..\..\External\juce\modules\juce_audio_processors_headless\format_types\LV2_SDK\README.md">
       <Filter>JUCE Modules\juce_audio_processors_headless\format_types\LV2_SDK</Filter>

--- a/Builds/VisualStudio2022/Signalizer_StandalonePlugin.vcxproj
+++ b/Builds/VisualStudio2022/Signalizer_StandalonePlugin.vcxproj
@@ -1,0 +1,181 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<Project DefaultTargets="Build"
+         ToolsVersion="17.0"
+         xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{1A84B065-5CAA-DD31-87FB-7FE760844AE8}</ProjectGuid>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props"/>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'"
+                 Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseOfMfc>false</UseOfMfc>
+    <WholeProgramOptimization>false</WholeProgramOptimization>
+    <PlatformToolset>v143</PlatformToolset>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'"
+                 Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseOfMfc>false</UseOfMfc>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <PlatformToolset>v143</PlatformToolset>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props"/>
+  <ImportGroup Label="ExtensionSettings"/>
+  <ImportGroup Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props"
+            Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')"
+            Label="LocalAppDataPlatform"/>
+  </ImportGroup>
+  <PropertyGroup>
+    <_ProjectFileVersion>10.0.30319.1</_ProjectFileVersion>
+    <TargetExt>.exe</TargetExt>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(SolutionDir)$(Platform)\$(Configuration)\Standalone Plugin\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(Platform)\$(Configuration)\Standalone Plugin\</IntDir>
+    <TargetName Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Signalizer</TargetName>
+    <GenerateManifest Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</GenerateManifest>
+    <LibraryPath Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(LibraryPath);$(SolutionDir)$(Platform)\$(Configuration)\Shared Code</LibraryPath>
+    <PreBuildEventUseInBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</PreBuildEventUseInBuild>
+    <PostBuildEventUseInBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</PostBuildEventUseInBuild>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(SolutionDir)$(Platform)\$(Configuration)\Standalone Plugin\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(Platform)\$(Configuration)\Standalone Plugin\</IntDir>
+    <TargetName Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Signalizer</TargetName>
+    <GenerateManifest Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</GenerateManifest>
+    <LibraryPath Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(LibraryPath);$(SolutionDir)$(Platform)\$(Configuration)\Shared Code</LibraryPath>
+    <PreBuildEventUseInBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</PreBuildEventUseInBuild>
+    <PostBuildEventUseInBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</PostBuildEventUseInBuild>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Midl>
+      <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <MkTypLibCompatible>true</MkTypLibCompatible>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <TargetEnvironment>Win32</TargetEnvironment>
+      <HeaderFileName/>
+    </Midl>
+    <ClCompile>
+      <Optimization>Disabled</Optimization>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <AdditionalIncludeDirectories>..\..\External\juce\modules\juce_audio_processors_headless\format_types\VST3_SDK;..\..\..\SDKs\vstsdk2.4;..\..\JuceLibraryCode;..\..\External\juce\modules;../../External;../../Source;../../Source/Config;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;_WINDOWS;DEBUG;_DEBUG;JUCE_GUI_BASICS_INCLUDE_SCOPED_THREAD_DPI_AWARENESS_SETTER=1;CPL_TRACEGUARD_ENTRYPOINTS;JUCER_VS2022_78A503E=1;JUCE_APP_VERSION=0.5.0;JUCE_APP_VERSION_HEX=0x500;JucePlugin_Build_VST=0;JucePlugin_Build_VST3=0;JucePlugin_Build_AU=0;JucePlugin_Build_AUv3=0;JucePlugin_Build_AAX=0;JucePlugin_Build_Standalone=1;JucePlugin_Build_Unity=0;JucePlugin_Build_LV2=0;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <RuntimeTypeInfo>true</RuntimeTypeInfo>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <AssemblerListingLocation>$(IntDir)\</AssemblerListingLocation>
+      <ObjectFileName>$(IntDir)\</ObjectFileName>
+      <ProgramDataBaseFileName>$(IntDir)\Signalizer.pdb</ProgramDataBaseFileName>
+      <WarningLevel>Level3</WarningLevel>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <FloatingPointModel>Fast</FloatingPointModel>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+    </ClCompile>
+    <ResourceCompile>
+      <AdditionalIncludeDirectories>..\..\External\juce\modules\juce_audio_processors_headless\format_types\VST3_SDK;..\..\..\SDKs\vstsdk2.4;..\..\JuceLibraryCode;..\..\External\juce\modules;../../External;../../Source;../../Source/Config;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;_WINDOWS;DEBUG;_DEBUG;JUCE_GUI_BASICS_INCLUDE_SCOPED_THREAD_DPI_AWARENESS_SETTER=1;CPL_TRACEGUARD_ENTRYPOINTS;JUCER_VS2022_78A503E=1;JUCE_APP_VERSION=0.5.0;JUCE_APP_VERSION_HEX=0x500;JucePlugin_Build_VST=0;JucePlugin_Build_VST3=0;JucePlugin_Build_AU=0;JucePlugin_Build_AUv3=0;JucePlugin_Build_AAX=0;JucePlugin_Build_Standalone=1;JucePlugin_Build_Unity=0;JucePlugin_Build_LV2=0;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ResourceCompile>
+    <Link>
+      <OutputFile>$(OutDir)\Signalizer.exe</OutputFile>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <IgnoreSpecificDefaultLibraries>libcmt.lib; msvcrt.lib;;%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <ProgramDatabaseFile>$(IntDir)\Signalizer.pdb</ProgramDatabaseFile>
+      <SubSystem>Windows</SubSystem>
+      <LargeAddressAware>true</LargeAddressAware>
+      <AdditionalDependencies>Signalizer.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+    <Bscmake>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <OutputFile>$(IntDir)\Signalizer.bsc</OutputFile>
+    </Bscmake>
+    <Lib>
+      <AdditionalDependencies>Signalizer.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Lib>
+    <PostBuildEvent>
+      <Command>cp -r ../../Make/Skeleton/* C:\Audio\VSTPlugins\Signalizer
+cp -r ../../Make/Skeleton/* &quot;x64\Debug\Standalone Plugin&quot;
+</Command>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Midl>
+      <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <MkTypLibCompatible>true</MkTypLibCompatible>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <TargetEnvironment>Win32</TargetEnvironment>
+      <HeaderFileName/>
+    </Midl>
+    <ClCompile>
+      <Optimization>Full</Optimization>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <AdditionalIncludeDirectories>..\..\External\juce\modules\juce_audio_processors_headless\format_types\VST3_SDK;..\..\..\SDKs\vstsdk2.4;..\..\JuceLibraryCode;..\..\External\juce\modules;../../External;../../Source;../../Source/Config;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;_WINDOWS;NDEBUG;JUCE_GUI_BASICS_INCLUDE_SCOPED_THREAD_DPI_AWARENESS_SETTER=1;CPL_TRACEGUARD_ENTRYPOINTS;JUCER_VS2022_78A503E=1;JUCE_APP_VERSION=0.5.0;JUCE_APP_VERSION_HEX=0x500;JucePlugin_Build_VST=0;JucePlugin_Build_VST3=0;JucePlugin_Build_AU=0;JucePlugin_Build_AUv3=0;JucePlugin_Build_AAX=0;JucePlugin_Build_Standalone=1;JucePlugin_Build_Unity=0;JucePlugin_Build_LV2=0;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <RuntimeTypeInfo>true</RuntimeTypeInfo>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <AssemblerListingLocation>$(IntDir)\</AssemblerListingLocation>
+      <ObjectFileName>$(IntDir)\</ObjectFileName>
+      <ProgramDataBaseFileName>$(IntDir)\Signalizer.pdb</ProgramDataBaseFileName>
+      <WarningLevel>Level3</WarningLevel>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <FloatingPointModel>Fast</FloatingPointModel>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+    </ClCompile>
+    <ResourceCompile>
+      <AdditionalIncludeDirectories>..\..\External\juce\modules\juce_audio_processors_headless\format_types\VST3_SDK;..\..\..\SDKs\vstsdk2.4;..\..\JuceLibraryCode;..\..\External\juce\modules;../../External;../../Source;../../Source/Config;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;_WINDOWS;NDEBUG;JUCE_GUI_BASICS_INCLUDE_SCOPED_THREAD_DPI_AWARENESS_SETTER=1;CPL_TRACEGUARD_ENTRYPOINTS;JUCER_VS2022_78A503E=1;JUCE_APP_VERSION=0.5.0;JUCE_APP_VERSION_HEX=0x500;JucePlugin_Build_VST=0;JucePlugin_Build_VST3=0;JucePlugin_Build_AU=0;JucePlugin_Build_AUv3=0;JucePlugin_Build_AAX=0;JucePlugin_Build_Standalone=1;JucePlugin_Build_Unity=0;JucePlugin_Build_LV2=0;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ResourceCompile>
+    <Link>
+      <OutputFile>$(OutDir)\Signalizer.exe</OutputFile>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <IgnoreSpecificDefaultLibraries>%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <ProgramDatabaseFile>$(IntDir)\Signalizer.pdb</ProgramDatabaseFile>
+      <SubSystem>Windows</SubSystem>
+      <OptimizeReferences>true</OptimizeReferences>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <LargeAddressAware>true</LargeAddressAware>
+      <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
+      <AdditionalDependencies>Signalizer.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+    <Bscmake>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <OutputFile>$(IntDir)\Signalizer.bsc</OutputFile>
+    </Bscmake>
+    <Lib>
+      <AdditionalDependencies>Signalizer.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Lib>
+    <PostBuildEvent>
+      <Command>cp -r ../../Make/Skeleton/* C:\Audio\VSTPlugins\Signalizer
+cp -r ../../Make/Skeleton/* &quot;x64\Release\Standalone Plugin&quot;
+</Command>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_plugin_client\juce_audio_plugin_client_Standalone.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\JuceLibraryCode\include_juce_audio_plugin_client_Standalone.cpp"/>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_plugin_client\Standalone\juce_StandaloneFilterWindow.h"/>
+  </ItemGroup>
+  <ItemGroup>
+    <ResourceCompile Include=".\resources.rc"/>
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets"/>
+</Project>

--- a/Builds/VisualStudio2022/Signalizer_StandalonePlugin.vcxproj.filters
+++ b/Builds/VisualStudio2022/Signalizer_StandalonePlugin.vcxproj.filters
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<Project ToolsVersion="17.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="JUCE Modules\juce_audio_plugin_client\Standalone">
+      <UniqueIdentifier>{725C0EA8-9736-764D-81E6-01695B6B00B3}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="JUCE Modules\juce_audio_plugin_client">
+      <UniqueIdentifier>{BA0A76FA-458F-0B1C-02E9-ECFBF81140EC}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="JUCE Modules">
+      <UniqueIdentifier>{FE955B6B-68AC-AA07-70D8-2413F6DB65C8}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="JUCE Library Code">
+      <UniqueIdentifier>{7ED5A90E-41AF-A1EF-659B-37CEEAB9BA61}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\External\juce\modules\juce_audio_plugin_client\juce_audio_plugin_client_Standalone.cpp">
+      <Filter>JUCE Modules\juce_audio_plugin_client</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\JuceLibraryCode\include_juce_audio_plugin_client_Standalone.cpp">
+      <Filter>JUCE Library Code</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\External\juce\modules\juce_audio_plugin_client\Standalone\juce_StandaloneFilterWindow.h">
+      <Filter>JUCE Modules\juce_audio_plugin_client\Standalone</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ResourceCompile Include=".\resources.rc">
+      <Filter>JUCE Library Code</Filter>
+    </ResourceCompile>
+  </ItemGroup>
+</Project>

--- a/Builds/VisualStudio2022/Signalizer_VST.vcxproj
+++ b/Builds/VisualStudio2022/Signalizer_VST.vcxproj
@@ -119,6 +119,7 @@ if exist &quot;C:\Audio\VSTPlugins\Signalizer\%TOUCH_NAME%&quot; (
     </PreBuildEvent>
     <PostBuildEvent>
       <Command>cp -r ../../Make/Skeleton/* C:\Audio\VSTPlugins\Signalizer
+cp -r ../../Make/Skeleton/* &quot;x64\Debug\Standalone Plugin&quot;
 mkdir &quot;C:\Audio\VSTPlugins\Signalizer&quot;
 copy /Y &quot;$(OutDir)$(TargetFileName)&quot; &quot;C:\Audio\VSTPlugins\Signalizer\$(TargetFileName)&quot;
 </Command>
@@ -188,6 +189,7 @@ if exist &quot;C:\Audio\VSTPlugins\Signalizer\%TOUCH_NAME%&quot; (
     </PreBuildEvent>
     <PostBuildEvent>
       <Command>cp -r ../../Make/Skeleton/* C:\Audio\VSTPlugins\Signalizer
+cp -r ../../Make/Skeleton/* &quot;x64\Release\Standalone Plugin&quot;
 mkdir &quot;C:\Audio\VSTPlugins\Signalizer&quot;
 copy /Y &quot;$(OutDir)$(TargetFileName)&quot; &quot;C:\Audio\VSTPlugins\Signalizer\$(TargetFileName)&quot;
 </Command>

--- a/Builds/VisualStudio2022/Signalizer_VST3.vcxproj
+++ b/Builds/VisualStudio2022/Signalizer_VST3.vcxproj
@@ -131,6 +131,7 @@ if not exist &quot;$(OutDir)\\Signalizer.vst3\Contents\x86_64-win\&quot; (
     </PreBuildEvent>
     <PostBuildEvent>
       <Command>cp -r ../../Make/Skeleton/* C:\Audio\VSTPlugins\Signalizer
+cp -r ../../Make/Skeleton/* &quot;x64\Debug\Standalone Plugin&quot;
 copy /Y &quot;$(OutDir)\Signalizer.dll&quot; &quot;$(OutDir)\Signalizer.vst3\Contents\x86_64-win\Signalizer.vst3&quot;
 if exist &quot;$(OutDir)\Signalizer.vst3\Contents\Resources\moduleinfo.json&quot; (
     del /s /q &quot;$(OutDir)\Signalizer.vst3\Contents\Resources\moduleinfo.json&quot;
@@ -220,6 +221,7 @@ if not exist &quot;$(OutDir)\\Signalizer.vst3\Contents\x86_64-win\&quot; (
     </PreBuildEvent>
     <PostBuildEvent>
       <Command>cp -r ../../Make/Skeleton/* C:\Audio\VSTPlugins\Signalizer
+cp -r ../../Make/Skeleton/* &quot;x64\Release\Standalone Plugin&quot;
 copy /Y &quot;$(OutDir)\Signalizer.dll&quot; &quot;$(OutDir)\Signalizer.vst3\Contents\x86_64-win\Signalizer.vst3&quot;
 if exist &quot;$(OutDir)\Signalizer.vst3\Contents\Resources\moduleinfo.json&quot; (
     del /s /q &quot;$(OutDir)\Signalizer.vst3\Contents\Resources\moduleinfo.json&quot;

--- a/Builds/VisualStudio2022/Signalizer_VST3ManifestHelper.vcxproj
+++ b/Builds/VisualStudio2022/Signalizer_VST3ManifestHelper.vcxproj
@@ -104,6 +104,7 @@
     </Manifest>
     <PostBuildEvent>
       <Command>cp -r ../../Make/Skeleton/* C:\Audio\VSTPlugins\Signalizer
+cp -r ../../Make/Skeleton/* &quot;x64\Debug\Standalone Plugin&quot;
 </Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
@@ -158,6 +159,7 @@
     </Manifest>
     <PostBuildEvent>
       <Command>cp -r ../../Make/Skeleton/* C:\Audio\VSTPlugins\Signalizer
+cp -r ../../Make/Skeleton/* &quot;x64\Release\Standalone Plugin&quot;
 </Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Universal binary support on macOS for x86 and arm (native "Apple Silicon" support)
 - HiDPI support on Windows
+- Standalone development support
 
 ### Fixed
 

--- a/JuceLibraryCode/AppConfig.h
+++ b/JuceLibraryCode/AppConfig.h
@@ -34,9 +34,12 @@
 
 //==============================================================================
 #define JUCE_MODULE_AVAILABLE_juce_audio_basics                   1
+#define JUCE_MODULE_AVAILABLE_juce_audio_devices                  1
+#define JUCE_MODULE_AVAILABLE_juce_audio_formats                  1
 #define JUCE_MODULE_AVAILABLE_juce_audio_plugin_client            1
 #define JUCE_MODULE_AVAILABLE_juce_audio_processors               1
 #define JUCE_MODULE_AVAILABLE_juce_audio_processors_headless      1
+#define JUCE_MODULE_AVAILABLE_juce_audio_utils                    1
 #define JUCE_MODULE_AVAILABLE_juce_core                           1
 #define JUCE_MODULE_AVAILABLE_juce_data_structures                1
 #define JUCE_MODULE_AVAILABLE_juce_events                         1
@@ -46,6 +49,80 @@
 #define JUCE_MODULE_AVAILABLE_juce_opengl                         1
 
 #define JUCE_GLOBAL_MODULE_SETTINGS_INCLUDED 1
+
+//==============================================================================
+// juce_audio_devices flags:
+
+#ifndef    JUCE_USE_WINRT_MIDI
+ //#define JUCE_USE_WINRT_MIDI 0
+#endif
+
+#ifndef    JUCE_USE_WINDOWS_MIDI_SERVICES
+ //#define JUCE_USE_WINDOWS_MIDI_SERVICES 0
+#endif
+
+#ifndef    JUCE_ASIO
+ //#define JUCE_ASIO 0
+#endif
+
+#ifndef    JUCE_ASIO_USE_EXTERNAL_SDK
+ //#define JUCE_ASIO_USE_EXTERNAL_SDK 0
+#endif
+
+#ifndef    JUCE_WASAPI
+ //#define JUCE_WASAPI 1
+#endif
+
+#ifndef    JUCE_DIRECTSOUND
+ #define   JUCE_DIRECTSOUND 0
+#endif
+
+#ifndef    JUCE_ALSA
+ //#define JUCE_ALSA 1
+#endif
+
+#ifndef    JUCE_JACK
+ //#define JUCE_JACK 0
+#endif
+
+#ifndef    JUCE_USE_ANDROID_OBOE
+ //#define JUCE_USE_ANDROID_OBOE 1
+#endif
+
+#ifndef    JUCE_USE_OBOE_STABILIZED_CALLBACK
+ //#define JUCE_USE_OBOE_STABILIZED_CALLBACK 0
+#endif
+
+#ifndef    JUCE_USE_ANDROID_OPENSLES
+ //#define JUCE_USE_ANDROID_OPENSLES 0
+#endif
+
+#ifndef    JUCE_DISABLE_AUDIO_MIXING_WITH_OTHER_APPS
+ //#define JUCE_DISABLE_AUDIO_MIXING_WITH_OTHER_APPS 0
+#endif
+
+//==============================================================================
+// juce_audio_formats flags:
+
+#ifndef    JUCE_USE_FLAC
+ #define   JUCE_USE_FLAC 0
+#endif
+
+#ifndef    JUCE_USE_OGGVORBIS
+ #define   JUCE_USE_OGGVORBIS 0
+#endif
+
+#ifndef    JUCE_USE_MP3AUDIOFORMAT
+ //#define JUCE_USE_MP3AUDIOFORMAT 0
+#endif
+
+#ifndef    JUCE_USE_LAME_AUDIO_FORMAT
+ //#define JUCE_USE_LAME_AUDIO_FORMAT 0
+#endif
+
+#ifndef    JUCE_USE_WINDOWS_MEDIA_FORMAT
+ #define   JUCE_USE_WINDOWS_MEDIA_FORMAT 0
+#endif
 
 //==============================================================================
 // juce_audio_plugin_client flags:
@@ -71,7 +148,7 @@
 #endif
 
 #ifndef    JUCE_STANDALONE_FILTER_WINDOW_USE_KIOSK_MODE
- #define   JUCE_STANDALONE_FILTER_WINDOW_USE_KIOSK_MODE 1
+ #define   JUCE_STANDALONE_FILTER_WINDOW_USE_KIOSK_MODE 0
 #endif
 
 #ifndef    JUCE_IGNORE_VST3_MISMATCHED_PARAMETER_ID_WARNING
@@ -107,6 +184,17 @@
 
 #ifndef    JUCE_CUSTOM_VST3_SDK
  //#define JUCE_CUSTOM_VST3_SDK 0
+#endif
+
+//==============================================================================
+// juce_audio_utils flags:
+
+#ifndef    JUCE_USE_CDREADER
+ //#define JUCE_USE_CDREADER 0
+#endif
+
+#ifndef    JUCE_USE_CDBURNER
+ //#define JUCE_USE_CDBURNER 0
 #endif
 
 //==============================================================================

--- a/JuceLibraryCode/JuceHeader.h
+++ b/JuceLibraryCode/JuceHeader.h
@@ -15,9 +15,12 @@
 #include "AppConfig.h"
 
 #include <juce_audio_basics/juce_audio_basics.h>
+#include <juce_audio_devices/juce_audio_devices.h>
+#include <juce_audio_formats/juce_audio_formats.h>
 #include <juce_audio_plugin_client/juce_audio_plugin_client.h>
 #include <juce_audio_processors/juce_audio_processors.h>
 #include <juce_audio_processors_headless/juce_audio_processors_headless.h>
+#include <juce_audio_utils/juce_audio_utils.h>
 #include <juce_core/juce_core.h>
 #include <juce_data_structures/juce_data_structures.h>
 #include <juce_events/juce_events.h>

--- a/JuceLibraryCode/include_juce_audio_devices.cpp
+++ b/JuceLibraryCode/include_juce_audio_devices.cpp
@@ -1,0 +1,9 @@
+/*
+
+    IMPORTANT! This file is auto-generated each time you save your
+    project - if you alter its contents, your changes may be overwritten!
+
+*/
+
+#include "AppConfig.h"
+#include <juce_audio_devices/juce_audio_devices.cpp>

--- a/JuceLibraryCode/include_juce_audio_devices.mm
+++ b/JuceLibraryCode/include_juce_audio_devices.mm
@@ -1,0 +1,9 @@
+/*
+
+    IMPORTANT! This file is auto-generated each time you save your
+    project - if you alter its contents, your changes may be overwritten!
+
+*/
+
+#include "AppConfig.h"
+#include <juce_audio_devices/juce_audio_devices.mm>

--- a/JuceLibraryCode/include_juce_audio_formats.cpp
+++ b/JuceLibraryCode/include_juce_audio_formats.cpp
@@ -1,0 +1,9 @@
+/*
+
+    IMPORTANT! This file is auto-generated each time you save your
+    project - if you alter its contents, your changes may be overwritten!
+
+*/
+
+#include "AppConfig.h"
+#include <juce_audio_formats/juce_audio_formats.cpp>

--- a/JuceLibraryCode/include_juce_audio_formats.mm
+++ b/JuceLibraryCode/include_juce_audio_formats.mm
@@ -1,0 +1,9 @@
+/*
+
+    IMPORTANT! This file is auto-generated each time you save your
+    project - if you alter its contents, your changes may be overwritten!
+
+*/
+
+#include "AppConfig.h"
+#include <juce_audio_formats/juce_audio_formats.mm>

--- a/JuceLibraryCode/include_juce_audio_utils.cpp
+++ b/JuceLibraryCode/include_juce_audio_utils.cpp
@@ -1,0 +1,9 @@
+/*
+
+    IMPORTANT! This file is auto-generated each time you save your
+    project - if you alter its contents, your changes may be overwritten!
+
+*/
+
+#include "AppConfig.h"
+#include <juce_audio_utils/juce_audio_utils.cpp>

--- a/JuceLibraryCode/include_juce_audio_utils.mm
+++ b/JuceLibraryCode/include_juce_audio_utils.mm
@@ -1,0 +1,9 @@
+/*
+
+    IMPORTANT! This file is auto-generated each time you save your
+    project - if you alter its contents, your changes may be overwritten!
+
+*/
+
+#include "AppConfig.h"
+#include <juce_audio_utils/juce_audio_utils.mm>

--- a/Make/__init__.py
+++ b/Make/__init__.py
@@ -1,3 +1,4 @@
 import sys
+import os
 
-sys.path.append("Make")
+sys.path.append(os.path.dirname(os.path.abspath(__file__)))

--- a/Make/build_win.py
+++ b/Make/build_win.py
@@ -6,6 +6,85 @@ import shutil as sh
 import zipfile as zip
 import common as cm
 import subprocess
+import re
+import datetime
+
+# Matches MSBuild/MSVC error lines: "path(line): error CODE: message"
+_ERROR_RE = re.compile(r': error \w', re.IGNORECASE)
+
+
+_VCVARSALL = r'C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvarsall.bat'
+
+def get_msvc_env(arch='x64'):
+	"""Return os.environ copy with MSVC toolchain loaded for the given arch."""
+	cmd = f'"{_VCVARSALL}" {arch} && set'
+	result = subprocess.run(cmd, capture_output=True, encoding='oem', shell=True)
+	env = {}
+	for line in result.stdout.splitlines():
+		if '=' in line:
+			k, v = line.split('=', 1)
+			env[k.upper()] = v
+	return env
+
+
+def run_msbuild(projects, config_str, arch, env, verbose, max_errors, logs_dir, solution_dir=None):
+	"""
+	Build a list of project/solution files in order using MSBuild.
+	Returns (success: bool, error_lines: list[str], log_path: str).
+	solution_dir is only needed when building .vcxproj files directly.
+	In verbose mode, output is streamed and error_lines is always empty.
+	"""
+	os.makedirs(logs_dir, exist_ok=True)
+	timestamp = datetime.datetime.now().strftime('%Y%m%d_%H%M%S')
+	log_path = os.path.join(logs_dir, f'build_{timestamp}.log')
+
+	msbuild = sh.which('msbuild', path=env.get('PATH', ''))
+	if not msbuild:
+		raise RuntimeError("msbuild not found in MSVC environment PATH")
+
+	all_lines = []
+
+	for project in projects:
+		cmd = [
+			msbuild, project,
+			f'/p:Configuration={config_str}',
+			f'/p:Platform={arch}',
+			'/nologo',
+			'/verbosity:quiet' if not verbose else '/verbosity:normal',
+		]
+		if solution_dir is not None:
+			cmd.append(f'/p:SolutionDir={solution_dir}')
+
+		if verbose:
+			proc = subprocess.Popen(cmd, env=env, stdout=subprocess.PIPE,
+			                        stderr=subprocess.STDOUT, text=True)
+			log_lines = []
+			for line in proc.stdout:
+				print(line, end='')
+				log_lines.append(line)
+			proc.wait()
+			all_lines.extend(log_lines)
+
+			if proc.returncode != 0:
+				with open(log_path, 'w') as f:
+					f.writelines(all_lines)
+				return False, [], log_path
+		else:
+			proc = subprocess.run(cmd, capture_output=True, text=True, env=env)
+			lines = proc.stdout.splitlines() + proc.stderr.splitlines()
+			all_lines.extend(lines)
+
+			if proc.returncode != 0:
+				with open(log_path, 'w') as f:
+					f.write('\n'.join(all_lines))
+				errors = [l for l in lines if _ERROR_RE.search(l)]
+				return False, errors[:max_errors], log_path
+
+	with open(log_path, 'w') as f:
+		f.write('\n'.join(all_lines))
+
+	return True, [], log_path
+
 
 def kvsz(key, value):
 	return "      VALUE " + "\"" + key + "\", \"" + value + "\\0\"\n"
@@ -45,8 +124,31 @@ def setup_resource(outputfile, major, minor, build, name, description, company):
 	with open(outputfile, "w") as out:
 		out.writelines(contents)
 
-def compiler_invoke(compiler_arch, target):
-	return os.system("vscompile.bat " + compiler_arch + " " + target)
+def build_dev(config):
+	"""Debug Standalone build. Returns the path to the built executable."""
+	vcxpath = os.path.abspath(cm.join("..", "Builds", "VisualStudio2022"))
+	solution_dir = vcxpath + "\\"
+
+	projects = [
+		cm.join(vcxpath, "Signalizer_SharedCode.vcxproj"),
+		cm.join(vcxpath, "Signalizer_StandalonePlugin.vcxproj"),
+	]
+
+	env = get_msvc_env(config.arch)
+	success, errors, log_path = run_msbuild(
+		projects, 'Debug', config.arch,
+		env, config.verbose, config.max_errors, config.logs_dir,
+		solution_dir=solution_dir
+	)
+
+	if not success:
+		print(f"------> Build failed (full log: {log_path})")
+		for line in errors:
+			print(line)
+		exit(1)
+
+	return cm.join(vcxpath, config.arch, "Debug", "Standalone Plugin", "Signalizer.exe"), log_path
+
 
 def build(program):
 
@@ -58,12 +160,16 @@ def build(program):
 	#overwrite resource to embed version numbers
 	setup_resource(cm.join(vcxpath, "resources.rc"), program.major, program.minor, program.build, program.name, program.desc, program.company)
 
-	#run all archs
-	archs = [["x64", f'"{program.configString}|x64"']]
-	for option in archs:
-		if compiler_invoke(option[0], option[1]) != 0:
-			print("\n------> Error compiling for target " + option[0])
-			exit(1)
+	env = get_msvc_env('x64')
+	success, errors, log_path = run_msbuild(
+		[cm.join(vcxpath, "Signalizer.sln")], program.configString, 'x64',
+		env, program.verbose, 5, 'Logs'
+	)
+	if not success:
+		print(f"\n------> Build failed (full log: {log_path})")
+		for line in errors:
+			print(line)
+		exit(1)
 
 	print("\n------> All builds finished, generating skeletons...")
 
@@ -99,4 +205,4 @@ def build(program):
 	if os.path.exists("Symbols"):
 		sh.rmtree("Symbols")
 
-	return zx + "\n" + zxpdb
+	return zx + "\n" + zxpdb, log_path

--- a/Make/common.py
+++ b/Make/common.py
@@ -5,9 +5,7 @@ import getpass
 import platform
 import configparser
 import sys
-import argparse
 import shutil as sh
-import platform
 
 join = os.path.join
 
@@ -17,9 +15,10 @@ is_mac = "darwin" in sys_name
 is_linux = "linux" in sys_name
 is_ubuntu = is_linux and "ubuntu" in platform.version().lower()
 
+
 def rewrite_version_header(where, major, minor, build):
 	build_info = get_custom_build_info().replace('\n', "\\n").replace('\r', "\\n")
-	contents = "#define SIGNALIZER_MAJOR " + major + "\n#define SIGNALIZER_MINOR " + minor + "\n#define SIGNALIZER_BUILD " + build 
+	contents = "#define SIGNALIZER_MAJOR " + major + "\n#define SIGNALIZER_MINOR " + minor + "\n#define SIGNALIZER_BUILD " + build
 	contents += "\n#define SIGNALIZER_BUILD_INFO \"" + build_info + "\"\n"
 	contents += "\n#define SIGNALIZER_VERSION " + major + "." + minor + "." + build
 	contents += "\n#define SIGNALIZER_VERSION_STRING \"" + major + "." + minor + "." + build + "\""
@@ -37,52 +36,52 @@ def create_build_file(where, vstring):
 
 	with open(where, "w") as out:
 		out.writelines(build_info)
-           # error sometimes?
 		out.writelines(git_log.decode('ascii'))
 
 def get_custom_build_info():
-    git = subprocess.Popen("git --git-dir ../.git branch -q", shell = True, stdout=subprocess.PIPE)
-    git_branch = git.stdout.read()
-    git = subprocess.Popen("git --git-dir ../.git describe --always", shell = True, stdout=subprocess.PIPE)
-    git_description = git.stdout.read()
-    return git_branch.decode('ascii') + "\n" + git_description.decode('ascii')
+	git = subprocess.Popen("git --git-dir ../.git branch -q", shell = True, stdout=subprocess.PIPE)
+	git_branch = git.stdout.read()
+	git = subprocess.Popen("git --git-dir ../.git describe --always", shell = True, stdout=subprocess.PIPE)
+	git_description = git.stdout.read()
+	return git_branch.decode('ascii') + "\n" + git_description.decode('ascii')
+
+
+class DevConfig:
+	def __init__(self, args):
+		if os.path.split(os.getcwd())[1] != "Make":
+			print("Error, this program must be called from within Make folder")
+			exit(-5)
+
+		self.arch = args.arch
+		self.verbose = args.verbose
+		self.max_errors = args.errors
+		self.logs_dir = "Logs"
+
 
 class ProgramConfig:
-	def __init__(self, inifile):
+	def __init__(self, args, inifile):
 
 		if os.path.split(os.getcwd())[1] != "Make":
 			print("Error, this program must be called from within Make folder")
-			exit(-5) 
+			exit(-5)
 
 		self.flush_parameters = False
 		self.inifile = inifile
-		parameters = []
-
-		parser = argparse.ArgumentParser()
-		parser.add_argument("-d", "--debug", action="store_true", help="Make a release with debug code generation")
-		parser.add_argument("-s", "--skipvst2", action="store_true", help="Try to make a release without depending on vst2 SDK (otherwise, place this at ../SDKs/vstsdk2.4)")
-
-		parser.add_argument("-j", "--increase-major", action="store_true", help="Increase the major version by 1")
-		parser.add_argument("-n", "--increase-minor", action="store_true", help="Increase the minor version by 1")
-		parser.add_argument("-b", "--increase-build", action="store_true", help="Increase the build version by 1")
-
-		args = parser.parse_args()
 
 		self.release = not args.debug
 		self.configString = "Release" if self.release else "Debug"
 		self.skipvst2 = args.skipvst2
+		self.verbose = args.verbose
 
 		self.config = configparser.ConfigParser()
 		self.config.read(inifile)
 
-		# handle operations
 		for param in [["major", args.increase_major], ["minor", args.increase_minor], ["build", args.increase_build]]:
 			if param[1]:
 				self.flush_parameters = True
 				self.config.set("version", param[0], str(int(self.config.get("version", param[0])) + 1))
 				print("------> Increasing " + param[0] + " to " + self.config.get("version", param[0]))
 
-		#configurations
 		self.major = self.config.get("version", "major")
 		self.minor = self.config.get("version", "minor")
 		self.build = self.config.get("version", "build")
@@ -97,7 +96,7 @@ class ProgramConfig:
 
 	def flush(self):
 		if self.flush_parameters:
-			with open(inifile, "w") as f:
+			with open(self.inifile, "w") as f:
 				self.config.write(f, True)
 
 	def rewrite_version_header(self):

--- a/Make/vscompile.bat
+++ b/Make/vscompile.bat
@@ -1,4 +1,0 @@
-call "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvarsall.bat" %1
-devenv "..\Builds\VisualStudio2022\Signalizer.sln" /build %2
-
-exit %ERRORLEVEL%

--- a/Signalizer.jucer
+++ b/Signalizer.jucer
@@ -10,13 +10,15 @@
               pluginSilenceInIsSilenceOut="1" pluginEditorRequiresKeys="0"
               pluginAUExportPrefix="SignalizerAU" pluginRTASCategory="" aaxIdentifier="com.Lightbridge.Signalizer"
               pluginAAXCategory="8192" companyName="Lightbridge" companyWebsite="www.jthorborg.com"
-              companyEmail="contact@jthorborg.com" pluginFormats="buildAU,buildVST,buildVST3"
-              buildAUv3="0" buildStandalone="0" enableIAA="0" pluginVST3Category="Analyzer"
+              companyEmail="contact@jthorborg.com" pluginFormats="buildAU,buildStandalone,buildVST,buildVST3"
+              buildAUv3="0" buildStandalone="1" enableIAA="0" pluginVST3Category="Analyzer"
               lv2Uri="https://jthorborg.com/index.html?ipage=signalizer" jucerFormatVersion="1"
               headerPath="../../External&#10;../../Source&#10;../../Source/Config"
               pluginVSTCategory="kPlugCategAnalysis">
   <MAINGROUP id="UevfpR" name="Signalizer">
     <GROUP id="{476E0AFE-C373-E089-79D2-4CB200759D8D}" name="Build">
+      <FILE id="mFxth0" name="build.py" compile="0" resource="0" file="build.py"
+            xcodeResource="0"/>
       <FILE id="klmFDx" name="build_linux.py" compile="0" resource="0" file="Make/build_linux.py"/>
       <FILE id="van5qI" name="build_osx.py" compile="0" resource="0" file="Make/build_osx.py"/>
       <FILE id="Acp04N" name="build_win.py" compile="0" resource="0" file="Make/build_win.py"/>
@@ -24,6 +26,7 @@
       <FILE id="so0jmk" name="config.ini" compile="0" resource="0" file="Make/config.ini"/>
       <FILE id="wULr24" name="macos_installation_advice.txt" compile="0"
             resource="0" file="Make/macos_installation_advice.txt"/>
+      <FILE id="yo8N5b" name="prepare.py" compile="0" resource="0" file="prepare.py"/>
       <FILE id="NJPDqg" name="vscompile.bat" compile="0" resource="0" file="Make/vscompile.bat"/>
       <FILE id="fUhex1" name="windows_installation_advice.txt" compile="0"
             resource="0" file="Make/windows_installation_advice.txt"/>
@@ -602,6 +605,9 @@
         <MODULEPATH id="juce_audio_plugin_client" path="External/juce/modules/"/>
         <MODULEPATH id="juce_audio_processors_headless" path="External/juce/modules"/>
         <MODULEPATH id="juce_audio_processors" path="External/juce/modules"/>
+        <MODULEPATH id="juce_audio_devices" path="External/juce/modules"/>
+        <MODULEPATH id="juce_audio_utils" path="External/juce/modules"/>
+        <MODULEPATH id="juce_audio_formats" path="External/juce/modules"/>
       </MODULEPATHS>
     </XCODE_MAC>
     <VS2022 targetFolder="Builds/VisualStudio2022" vstLegacyFolder="../SDKs/vstsdk2.4"
@@ -609,11 +615,11 @@
       <CONFIGURATIONS>
         <CONFIGURATION isDebug="1" name="Debug" fastMath="1" enablePluginBinaryCopyStep="1"
                        vstBinaryLocation_x64="C:\Audio\VSTPlugins\Signalizer" winWarningLevel="3"
-                       postbuildCommand="cp -r ../../Make/Skeleton/* C:\Audio\VSTPlugins\Signalizer"
+                       postbuildCommand="cp -r ../../Make/Skeleton/* C:\Audio\VSTPlugins\Signalizer&#10;cp -r ../../Make/Skeleton/* &quot;x64\Debug\Standalone Plugin&quot;"
                        winArchitecture="x64"/>
         <CONFIGURATION isDebug="0" name="Release" fastMath="1" useRuntimeLibDLL="0"
                        enablePluginBinaryCopyStep="1" vstBinaryLocation_x64="C:\Audio\VSTPlugins\Signalizer"
-                       winWarningLevel="3" postbuildCommand="cp -r ../../Make/Skeleton/* C:\Audio\VSTPlugins\Signalizer"
+                       winWarningLevel="3" postbuildCommand="cp -r ../../Make/Skeleton/* C:\Audio\VSTPlugins\Signalizer&#10;cp -r ../../Make/Skeleton/* &quot;x64\Release\Standalone Plugin&quot;"
                        alwaysGenerateDebugSymbols="1" winArchitecture="x64"/>
       </CONFIGURATIONS>
       <MODULEPATHS>
@@ -628,6 +634,9 @@
         <MODULEPATH id="juce_opengl" path="External/juce/modules/"/>
         <MODULEPATH id="juce_audio_processors_headless" path="External/juce/modules"/>
         <MODULEPATH id="juce_audio_processors" path="External/juce/modules"/>
+        <MODULEPATH id="juce_audio_devices" path="External/juce/modules"/>
+        <MODULEPATH id="juce_audio_utils" path="External/juce/modules"/>
+        <MODULEPATH id="juce_audio_formats" path="External/juce/modules"/>
       </MODULEPATHS>
     </VS2022>
     <LINUX_MAKE targetFolder="Builds/LinuxMakefile" vstLegacyFolder="../SDKs/vstsdk2.4"
@@ -649,15 +658,21 @@
         <MODULEPATH id="juce_opengl" path="External/juce/modules/"/>
         <MODULEPATH id="juce_audio_processors_headless" path="External/juce/modules"/>
         <MODULEPATH id="juce_audio_processors" path="External/juce/modules"/>
+        <MODULEPATH id="juce_audio_devices" path="External/juce/modules"/>
+        <MODULEPATH id="juce_audio_utils" path="External/juce/modules"/>
+        <MODULEPATH id="juce_audio_formats" path="External/juce/modules"/>
       </MODULEPATHS>
     </LINUX_MAKE>
   </EXPORTFORMATS>
   <MODULES>
     <MODULES id="juce_audio_basics" showAllCode="1" useLocalCopy="0"/>
+    <MODULE id="juce_audio_devices" showAllCode="1" useLocalCopy="0" useGlobalPath="0"/>
+    <MODULE id="juce_audio_formats" showAllCode="1" useLocalCopy="0" useGlobalPath="0"/>
     <MODULES id="juce_audio_plugin_client" showAllCode="1" useLocalCopy="0"/>
     <MODULE id="juce_audio_processors" showAllCode="1" useLocalCopy="0" useGlobalPath="0"/>
     <MODULE id="juce_audio_processors_headless" showAllCode="1" useLocalCopy="0"
             useGlobalPath="0"/>
+    <MODULE id="juce_audio_utils" showAllCode="1" useLocalCopy="0" useGlobalPath="0"/>
     <MODULES id="juce_core" showAllCode="1" useLocalCopy="0"/>
     <MODULES id="juce_data_structures" showAllCode="1" useLocalCopy="0"/>
     <MODULES id="juce_events" showAllCode="1" useLocalCopy="0"/>
@@ -667,7 +682,8 @@
     <MODULES id="juce_opengl" showAllCode="1" useLocalCopy="0"/>
   </MODULES>
   <JUCEOPTIONS JUCE_QUICKTIME="0" JUCE_FORCE_LEGACY_PARAMETER_AUTOMATION_TYPE="1"
-               JUCE_FORCE_USE_LEGACY_PARAM_IDS="1" JUCE_STANDALONE_FILTER_WINDOW_USE_KIOSK_MODE="1"
+               JUCE_FORCE_USE_LEGACY_PARAM_IDS="1" JUCE_STANDALONE_FILTER_WINDOW_USE_KIOSK_MODE="0"
                JUCE_USE_CURL="0" JUCE_INCLUDE_ZLIB_CODE="1" JUCE_ENABLE_DIRECT2D_CLEARTYPE_FONT_SMOOTHING="1"
-               JUCE_WIN_PER_MONITOR_DPI_AWARE="1" JUCE_WEB_BROWSER="0"/>
+               JUCE_WIN_PER_MONITOR_DPI_AWARE="1" JUCE_WEB_BROWSER="0" JUCE_DIRECTSOUND="0"
+               JUCE_USE_FLAC="0" JUCE_USE_OGGVORBIS="0" JUCE_USE_WINDOWS_MEDIA_FORMAT="0"/>
 </JUCERPROJECT>

--- a/build.py
+++ b/build.py
@@ -1,29 +1,63 @@
 import os
-import Make.common as cm
+import argparse
+
+parser = argparse.ArgumentParser(prog='build.py')
+sub = parser.add_subparsers(dest='mode', required=True)
+
+dev_p = sub.add_parser('dev', help='Debug Standalone build for development/testing')
+dev_p.add_argument('--arch', default='x64', choices=['x64', 'arm64'])
+dev_p.add_argument('--verbose', action='store_true', help='Stream full build output')
+dev_p.add_argument('--errors', type=int, default=3, metavar='N',
+                   help='Max errors to print on failure (default: 3)')
+
+rel_p = sub.add_parser('release', help='Full release build with packaging')
+rel_p.add_argument('-d', '--debug', action='store_true', help='Debug code generation')
+rel_p.add_argument('-s', '--skipvst2', action='store_true',
+                   help='Build without VST2 SDK dependency')
+rel_p.add_argument('--verbose', action='store_true', help='Stream full build output')
+rel_p.add_argument('-j', '--increase-major', action='store_true')
+rel_p.add_argument('-n', '--increase-minor', action='store_true')
+rel_p.add_argument('-b', '--increase-build', action='store_true')
+
+args = parser.parse_args()
+
+os.chdir('Make')
 
 try:
+    if args.mode == 'dev':
+        import Make.common as cm
+        # TODO: Implement development builds on other platforms.
+        import Make.build_win as bw
+        config = cm.DevConfig(args)
+        print(f"------> Building Signalizer Debug Standalone {config.arch} targets")
+        binary, log_path = bw.build_dev(config)
+        print("------> Built Signalizer successfully into:")
+        print(binary)
+        if not config.verbose:
+            print(f"------> Build log: {log_path}")
 
-	os.chdir("Make")
+    elif args.mode == 'release':
+        import Make.common as cm
+        program = cm.ProgramConfig(args, 'config.ini')
+        print("------> Building Signalizer v. " + program.version_string + " " + program.configString + " targets")
+        program.rewrite_version_header()
 
-	program = cm.ProgramConfig("config.ini")
-	print("------> Building Signalizer v. " + program.version_string + " " + program.configString + " targets")
-	program.rewrite_version_header()
+        log_path = None
+        if cm.is_linux:
+            import Make.build_linux as bl
+            zx = bl.build(program)
+        elif cm.is_windows:
+            import Make.build_win as bw
+            zx, log_path = bw.build(program)
+        elif cm.is_mac:
+            import Make.build_osx as bo
+            zx = bo.build(program)
 
-	if cm.is_linux:
-		import Make.build_linux as build_linux
-		zx = build_linux.build(program)
-	elif cm.is_windows:
-		import Make.build_win as build_win
-		zx = build_win.build(program)
-	elif cm.is_mac:
-		import Make.build_osx as build_osx
-		zx = build_osx.build(program)
-		
-	print("------> Built Signalizer successfully into:")
-	print(zx)
-
-	# done, if we made it here, increase the conf build
-	program.flush()
+        print("------> Built Signalizer successfully into:")
+        print(zx)
+        if log_path and not program.verbose:
+            print(f"------> Build log: {log_path}")
+        program.flush()
 
 finally:
-	os.chdir("..")
+    os.chdir('..')


### PR DESCRIPTION
New modes for `build.py`: `dev` or `release` with non-verbose output by default.